### PR TITLE
Release for v0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.0.13](https://github.com/Songmu/rcpr/compare/v0.0.12...v0.0.13) - 2022-08-27
+- add actions.yml to support GitHub Actions by @Songmu in https://github.com/Songmu/rcpr/pull/63
+- support to specify multiple version files by comma separated string in conf by @Songmu in https://github.com/Songmu/rcpr/pull/65
+- adjust bumping version file behavior by @Songmu in https://github.com/Songmu/rcpr/pull/66
+- remove generated comment in CHANGELOG.md by @Songmu in https://github.com/Songmu/rcpr/pull/67
+
 ## [v0.0.12](https://github.com/Songmu/rcpr/compare/v0.0.11...v0.0.12) - 2022-08-27
 - adjust default pull request body by @Songmu in https://github.com/Songmu/rcpr/pull/52
 - fix remote name detection by @Songmu in https://github.com/Songmu/rcpr/pull/54

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "A version to install rcpr"
     required: false
-    default: "v0.0.12"
+    default: "v0.0.13"
 runs:
   using: "composite"
   steps:

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package rcpr
 
-const version = "0.0.12"
+const version = "0.0.13"
 
 var revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.0.13 created by [rcpr](https://github.com/Songmu/rcpr). Merging it will tag v0.0.13 to the merge commit and create a GitHub release.

You can modify this branch "rcpr-from-v0.0.12" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .rcpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "rcpr:minor" or "rcpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* add actions.yml to support GitHub Actions by @Songmu in https://github.com/Songmu/rcpr/pull/63
* support to specify multiple version files by comma separated string in conf by @Songmu in https://github.com/Songmu/rcpr/pull/65
* adjust bumping version file behavior by @Songmu in https://github.com/Songmu/rcpr/pull/66
* remove generated comment in CHANGELOG.md by @Songmu in https://github.com/Songmu/rcpr/pull/67


**Full Changelog**: https://github.com/Songmu/rcpr/compare/v0.0.12...v0.0.13