### PR TITLE
Release for v0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.0.13](https://github.com/Songmu/tagpr/compare/v0.0.12...v0.0.13) - 2022-08-28
+- add actions.yml to support GitHub Actions by @Songmu in https://github.com/Songmu/tagpr/pull/63
+- support to specify multiple version files by comma separated string in conf by @Songmu in https://github.com/Songmu/tagpr/pull/65
+- adjust bumping version file behavior by @Songmu in https://github.com/Songmu/tagpr/pull/66
+- remove generated comment in CHANGELOG.md by @Songmu in https://github.com/Songmu/tagpr/pull/67
+- rename tool name to tagpr from rcpr by @Songmu in https://github.com/Songmu/tagpr/pull/68
+
 ## [v0.0.12](https://github.com/Songmu/tagpr/compare/v0.0.11...v0.0.12) - 2022-08-27
 - adjust default pull request body by @Songmu in https://github.com/Songmu/tagpr/pull/52
 - fix remote name detection by @Songmu in https://github.com/Songmu/tagpr/pull/54

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "A version to install tagpr"
     required: false
-    default: "v0.0.12"
+    default: "v0.0.13"
 runs:
   using: "composite"
   steps:

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package tagpr
 
-const version = "0.0.12"
+const version = "0.0.13"
 
 var revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.0.13 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.13 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.12" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* add actions.yml to support GitHub Actions by @Songmu in https://github.com/Songmu/tagpr/pull/63
* support to specify multiple version files by comma separated string in conf by @Songmu in https://github.com/Songmu/tagpr/pull/65
* adjust bumping version file behavior by @Songmu in https://github.com/Songmu/tagpr/pull/66
* remove generated comment in CHANGELOG.md by @Songmu in https://github.com/Songmu/tagpr/pull/67
* rename tool name to tagpr from rcpr by @Songmu in https://github.com/Songmu/tagpr/pull/68


**Full Changelog**: https://github.com/Songmu/tagpr/compare/v0.0.12...v0.0.13