### PR TITLE
Release for v0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.14](https://github.com/Songmu/tagpr/compare/v0.0.13...v0.0.14) - 2022-08-28
+- fix version file detection in releasing by @Songmu in https://github.com/Songmu/tagpr/pull/70
+
 ## [v0.0.13](https://github.com/Songmu/tagpr/compare/v0.0.12...v0.0.13) - 2022-08-28
 - add actions.yml to support GitHub Actions by @Songmu in https://github.com/Songmu/tagpr/pull/63
 - support to specify multiple version files by comma separated string in conf by @Songmu in https://github.com/Songmu/tagpr/pull/65

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "A version to install tagpr"
     required: false
-    default: "v0.0.13"
+    default: "v0.0.14"
 runs:
   using: "composite"
   steps:

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package tagpr
 
-const version = "0.0.13"
+const version = "0.0.14"
 
 var revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.0.14 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.14 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.13" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix version file detection in releasing by @Songmu in https://github.com/Songmu/tagpr/pull/70


**Full Changelog**: https://github.com/Songmu/tagpr/compare/v0.0.13...v0.0.14