### PR TITLE
Release for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.1.0](https://github.com/Songmu/tagpr/compare/v0.0.15...v0.1.0) - 2022-09-03
+- update dependency by @Songmu in https://github.com/Songmu/tagpr/pull/76
+- update README.md by @Songmu in https://github.com/Songmu/tagpr/pull/78
+
 ## [v0.0.15](https://github.com/Songmu/tagpr/compare/v0.0.14...v0.0.15) - 2022-08-31
 - enhance docs by @Songmu in https://github.com/Songmu/tagpr/pull/72
 - adjust template args by @Songmu in https://github.com/Songmu/tagpr/pull/74

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "A version to install tagpr"
     required: false
-    default: "v0.0.15"
+    default: "v0.1.0"
 runs:
   using: "composite"
   steps:

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package tagpr
 
-const version = "0.0.15"
+const version = "0.1.0"
 
 var revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.1.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.15" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* update dependency by @Songmu in https://github.com/Songmu/tagpr/pull/76
* update README.md by @Songmu in https://github.com/Songmu/tagpr/pull/78


**Full Changelog**: https://github.com/Songmu/tagpr/compare/v0.0.15...v0.1.0