### PR TITLE
feat: Add flag to turn on or off creating/modifying CHANGELOG.md

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -14,12 +14,7 @@
 #
 #   tagpr.vPrefix
 #       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
-#
-#   tagpr.changelog
-#       Flag whether or not changelog is added or changed during the release.
-#
 [tagpr]
 	vPrefix = true
-	changelog = true
 	releaseBranch = main
 	versionFile = version.go,action.yml

--- a/.tagpr
+++ b/.tagpr
@@ -14,7 +14,12 @@
 #
 #   tagpr.vPrefix
 #       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#
+#   tagpr.changelog
+#       Flag whether or not changelog is added or changed during the release.
+#
 [tagpr]
 	vPrefix = true
+	changelog = true
 	releaseBranch = main
 	versionFile = version.go,action.yml

--- a/config.go
+++ b/config.go
@@ -42,11 +42,13 @@ const (
 	envReleaseBranch    = "TAGPR_RELEASE_BRANCH"
 	envVersionFile      = "TAGPR_VERSION_FILE"
 	envVPrefix          = "TAGPR_VPREFIX"
+	envChangelog        = "TAGPR_CHANGELOG"
 	envCommand          = "TAGPR_COMMAND"
 	envTemplate         = "TAGPR_TEMPLATE"
 	configReleaseBranch = "tagpr.releaseBranch"
 	configVersionFile   = "tagpr.versionFile"
 	configVPrefix       = "tagpr.vPrefix"
+	configChangelog     = "tagpr.changelog"
 	configCommand       = "tagpr.command"
 	configTemplate      = "tagpr.template"
 )
@@ -113,6 +115,19 @@ func (cfg *config) Reload() error {
 		b, err := cfg.gitconfig.Bool(configVPrefix)
 		if err == nil {
 			cfg.vPrefix = github.Bool(b)
+		}
+	}
+
+	if changelog := os.Getenv(envChangelog); changelog != "" {
+		b, err := strconv.ParseBool(changelog)
+		if err != nil {
+			return err
+		}
+		cfg.changelog = github.Bool(b)
+	} else {
+		b, err := cfg.gitconfig.Bool(configChangelog)
+		if err == nil {
+			cfg.changelog = github.Bool(b)
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -29,6 +29,9 @@ const (
 #       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
 #       This is only a tagging convention, not how it is described in the version file.
 #
+#   tagpr.changelog (Optional)
+#       Flag whether or not changelog is added or changed during the release.
+#
 #   tagpr.command (Optional)
 #       Command to change files just before release.
 #
@@ -54,6 +57,7 @@ type config struct {
 	command       *configValue
 	template      *configValue
 	vPrefix       *bool
+	changelog     *bool
 
 	conf      string
 	gitconfig *gitconfig.Config

--- a/tagpr.go
+++ b/tagpr.go
@@ -299,21 +299,22 @@ func (tp *tagpr) Run(ctx context.Context) error {
 		}
 	}
 
-	if tp.cfg.changelog == nil || *tp.cfg.changelog {
-		gch, err := gh2changelog.New(ctx,
-			gh2changelog.GitPath(tp.gitPath),
-			gh2changelog.SetOutputs(tp.c.outStream, tp.c.errStream),
-			gh2changelog.GitHubClient(tp.gh),
-		)
-		if err != nil {
-			return err
-		}
+	gch, err := gh2changelog.New(ctx,
+		gh2changelog.GitPath(tp.gitPath),
+		gh2changelog.SetOutputs(tp.c.outStream, tp.c.errStream),
+		gh2changelog.GitHubClient(tp.gh),
+	)
+	if err != nil {
+		return err
+	}
 
+	changelog, orig, err := gch.Draft(ctx, nextVer.Tag(), time.Now())
+	if err != nil {
+		return err
+	}
+
+	if tp.cfg.changelog == nil || *tp.cfg.changelog {
 		changelogMd := "CHANGELOG.md"
-		changelog, orig, err := gch.Draft(ctx, nextVer.Tag(), time.Now())
-		if err != nil {
-			return err
-		}
 		if !exists(changelogMd) {
 			logs, _, err := gch.Changelogs(ctx, 20)
 			if err != nil {


### PR DESCRIPTION
Since our project is not using CHANGELOG.md, creating or modifying them by tagpr is not needed for us. This pull request proposes to add a flag to turn on/off the feature by .tagpr configuration file for people who wants turn it off like us.
