### PR TITLE
Release for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.3.0](https://github.com/Songmu/tagpr/compare/v0.2.0...v0.3.0) - 2022-09-17
+- add convention labels from labels of existing pull requests by @Songmu in https://github.com/Songmu/tagpr/pull/93
+- refine around type config by @Songmu in https://github.com/Songmu/tagpr/pull/94
+- add tagpr.release setting to adjust creating GitHub Release behavior by @Songmu in https://github.com/Songmu/tagpr/pull/95
+- true/false/draft for tapgr.release config by @Songmu in https://github.com/Songmu/tagpr/pull/96
+- GitHub Actions friendly outputs by @Songmu in https://github.com/Songmu/tagpr/pull/97
+
 ## [v0.2.0](https://github.com/Songmu/tagpr/compare/v0.1.3...v0.2.0) - 2022-09-06
 - feat: Add flag to turn on or off creating/modifying CHANGELOG.md by @siketyan in https://github.com/Songmu/tagpr/pull/86
 

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "A version to install tagpr"
     required: false
-    default: "v0.2.0"
+    default: "v0.3.0"
 runs:
   using: "composite"
   steps:

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package tagpr
 
-const version = "0.2.0"
+const version = "0.3.0"
 
 var revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.3.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* add convention labels from labels of existing pull requests by @Songmu in https://github.com/Songmu/tagpr/pull/93
* refine around type config by @Songmu in https://github.com/Songmu/tagpr/pull/94
* add tagpr.release setting to adjust creating GitHub Release behavior by @Songmu in https://github.com/Songmu/tagpr/pull/95
* true/false/draft for tapgr.release config by @Songmu in https://github.com/Songmu/tagpr/pull/96
* GitHub Actions friendly outputs by @Songmu in https://github.com/Songmu/tagpr/pull/97


**Full Changelog**: https://github.com/Songmu/tagpr/compare/v0.2.0...v0.3.0