### PR TITLE
Release for v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.3.1](https://github.com/Songmu/tagpr/compare/v0.3.0...v0.3.1) - 2022-09-17
+- update docs by @Songmu in https://github.com/Songmu/tagpr/pull/99
+- adjust label convention by @Songmu in https://github.com/Songmu/tagpr/pull/101
+- fix label convention by @Songmu in https://github.com/Songmu/tagpr/pull/102
+
 ## [v0.3.0](https://github.com/Songmu/tagpr/compare/v0.2.0...v0.3.0) - 2022-09-17
 - add convention labels from labels of existing pull requests by @Songmu in https://github.com/Songmu/tagpr/pull/93
 - refine around type config by @Songmu in https://github.com/Songmu/tagpr/pull/94

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "A version to install tagpr"
     required: false
-    default: "v0.3.0"
+    default: "v0.3.1"
 runs:
   using: "composite"
   steps:

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package tagpr
 
-const version = "0.3.0"
+const version = "0.3.1"
 
 var revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.3.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* update docs by @Songmu in https://github.com/Songmu/tagpr/pull/99
* adjust label convention by @Songmu in https://github.com/Songmu/tagpr/pull/101
* fix label convention by @Songmu in https://github.com/Songmu/tagpr/pull/102


**Full Changelog**: https://github.com/Songmu/tagpr/compare/v0.3.0...v0.3.1