### PR TITLE
Release for v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.3.2](https://github.com/Songmu/tagpr/compare/v0.3.1...v0.3.2) - 2022-09-17
+- add vN tag after uploading artifacts by @Songmu in https://github.com/Songmu/tagpr/pull/103
+- update dependencies by @Songmu in https://github.com/Songmu/tagpr/pull/105
+
 ## [v0.3.1](https://github.com/Songmu/tagpr/compare/v0.3.0...v0.3.1) - 2022-09-17
 - update docs by @Songmu in https://github.com/Songmu/tagpr/pull/99
 - adjust label convention by @Songmu in https://github.com/Songmu/tagpr/pull/101

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "A version to install tagpr"
     required: false
-    default: "v0.3.1"
+    default: "v0.3.2"
 runs:
   using: "composite"
   steps:

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package tagpr
 
-const version = "0.3.1"
+const version = "0.3.2"
 
 var revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.3.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* add vN tag after uploading artifacts by @Songmu in https://github.com/Songmu/tagpr/pull/103
* update dependencies by @Songmu in https://github.com/Songmu/tagpr/pull/105


**Full Changelog**: https://github.com/Songmu/tagpr/compare/v0.3.1...v0.3.2