### PR TITLE
Release for v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.3.3](https://github.com/Songmu/tagpr/compare/v0.3.2...v0.3.3) - 2022-09-17
+- use install.sh in action.yml by @Songmu in https://github.com/Songmu/tagpr/pull/106
+
 ## [v0.3.2](https://github.com/Songmu/tagpr/compare/v0.3.1...v0.3.2) - 2022-09-17
 - add vN tag after uploading artifacts by @Songmu in https://github.com/Songmu/tagpr/pull/103
 - update dependencies by @Songmu in https://github.com/Songmu/tagpr/pull/105

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "A version to install tagpr"
     required: false
-    default: "v0.3.2"
+    default: "v0.3.3"
 runs:
   using: "composite"
   steps:

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package tagpr
 
-const version = "0.3.2"
+const version = "0.3.3"
 
 var revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.3.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* use install.sh in action.yml by @Songmu in https://github.com/Songmu/tagpr/pull/106


**Full Changelog**: https://github.com/Songmu/tagpr/compare/v0.3.2...v0.3.3