### PR TITLE
don't update versionFile configuration if .tagpr file already exists

### DIFF
--- a/tagpr.go
+++ b/tagpr.go
@@ -303,7 +303,7 @@ OUT:
 		for i, v := range vfiles {
 			vfiles[i] = strings.TrimSpace(v)
 		}
-	} else {
+	} else if tp.cfg.versionFile == nil {
 		vfile, err := detectVersionFile(".", currVer)
 		if err != nil {
 			return err


### PR DESCRIPTION
In the current implementation, even if a .tagpr file exists and the version file setting is empty, it still detects and updates the file. It is incorrect behavior.

Sometimes version files are intentionally set to an empty string, and in such cases, it is confusing to users to detect version files on tagpr's own. Also, since version file detection is done heuristically, false positives can occur.

After the initial setting, even if it is an empty string, the version file information should be changed by the developers themselves and should not be touched by tagpr.

This behavior was informed by @griffin-stewie. Thanks.