### PR TITLE
SetOutput in GitHub Actions with new way

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -2,7 +2,6 @@ package tagpr
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/google/go-github/v47/github"
@@ -95,8 +94,7 @@ func (tp *tagpr) tagRelease(ctx context.Context, pr *github.PullRequest, currVer
 	if err != nil {
 		return err
 	}
-
-	fmt.Fprintf(tp.out, "::set-output name=tag::%s\n", nextTag)
+	tp.setOutput("tag", nextTag)
 
 	if !tp.cfg.Release() {
 		return nil

--- a/tagpr.go
+++ b/tagpr.go
@@ -176,7 +176,7 @@ func (tp *tagpr) Run(ctx context.Context) error {
 			return err
 		}
 		b, _ := json.Marshal(pr)
-		fmt.Fprintf(tp.out, "::set-output name=pull_request::%s\n", string(b))
+		tp.setOutput("pull_request", string(b))
 		return nil
 	}
 	shasStr, _, err := tp.c.Git("log", "--merges", "--pretty=format:%P",
@@ -486,7 +486,7 @@ OUT:
 			pr = tmpPr
 		}
 		b, _ := json.Marshal(pr)
-		fmt.Fprintf(tp.out, "::set-output name=pull_request::%s\n", string(b))
+		tp.setOutput("pull_request", string(b))
 		return nil
 	}
 	currTagPR.Title = github.String(title)
@@ -507,7 +507,7 @@ OUT:
 		}
 	}
 	b, _ := json.Marshal(pr)
-	fmt.Fprintf(tp.out, "::set-output name=pull_request::%s\n", string(b))
+	tp.setOutput("pull_request", string(b))
 	return nil
 }
 

--- a/util.go
+++ b/util.go
@@ -1,8 +1,16 @@
 package tagpr
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 func exists(filename string) bool {
 	_, err := os.Stat(filename)
 	return err == nil
+}
+
+func (tp *tagpr) setOutput(name, value string) error {
+	_, err := fmt.Fprintf(tp.out, "::set-output name=%s::%s\n", name, value)
+	return err
 }

--- a/util.go
+++ b/util.go
@@ -11,6 +11,20 @@ func exists(filename string) bool {
 }
 
 func (tp *tagpr) setOutput(name, value string) error {
-	_, err := fmt.Fprintf(tp.out, "::set-output name=%s::%s\n", name, value)
+	return setOutput(name, value)
+}
+
+func setOutput(name, value string) error {
+	fpath, ok := os.LookupEnv("GITHUB_OUTPUT")
+	if !ok {
+		return nil
+	}
+	f, err := os.OpenFile(fpath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(fmt.Sprintf("%s=%s\n", name, value))
 	return err
 }


### PR DESCRIPTION
SetOutput with stdout in GitHub Actions are deprecated.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/