### PR TITLE
Use the official actions/create-github-app-token Action instead of tibdex/github-app-token

### DIFF
--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -13,10 +13,10 @@ jobs:
         go-version: 1.x
     - name: Generate token
       id: generate_token
-      uses: tibdex/github-app-token@v1
+      uses: actions/create-github-app-token@v1
       with:
-        app_id: ${{ secrets.APP_ID }}
-        private_key: ${{ secrets.PRIVATE_KEY }}
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
     - name: checkout
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Recently, an official Action for retrieving a GitHub App token was released.

https://github.com/actions/create-github-app-token

I propose using this instead of a third-party action. (Also, it may help to update the [README](https://github.com/Songmu/tagpr#synopsis) for new users).