### PR TITLE
Consider vPrefix when retrieving the latest semver tag.

### DIFF
--- a/tagpr.go
+++ b/tagpr.go
@@ -42,8 +42,11 @@ type tagpr struct {
 
 func (tp *tagpr) latestSemverTag() string {
 	vers := (&gitsemvers.Semvers{GitPath: tp.gitPath}).VersionStrings()
-	if len(vers) > 0 {
-		return vers[0]
+	vPrefix := (tp.cfg.vPrefix != nil && *tp.cfg.vPrefix)
+	for _, v := range vers {
+		if strings.HasPrefix(v, "v") == vPrefix {
+			return v
+		}
 	}
 	return ""
 }

--- a/tagpr_test.go
+++ b/tagpr_test.go
@@ -310,6 +310,35 @@ func TestGeneratenNextLabels(t *testing.T) {
 	}
 }
 
+func TestLatestSemverTag(t *testing.T) {
+	tests := []struct {
+		name    string
+		vPrefix bool
+		wantVer bool
+	}{
+		{"github.com/Songmu/tagpr has a semver tag with 'v' prefix", true, true},
+		{"github.com/Songmu/tagpr has no semver tag without 'v' prefix", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tp, err := newTagPR(context.Background(), &commander{
+				gitPath: "git", outStream: os.Stdout, errStream: os.Stderr, dir: "."},
+			)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			tp.cfg = &config{
+				vPrefix: &tt.vPrefix,
+			}
+			got := tp.latestSemverTag()
+			if (got != "") != tt.wantVer {
+				t.Errorf("got: %s, wantVer: %t", got, tt.wantVer)
+			}
+		})
+	}
+}
+
 func newGithubLabel(name *string) *github.Label {
 	return &github.Label{
 		ID:          new(int64),


### PR DESCRIPTION
Hi @Songmu.

I am currently operating a repository with a mix of "semver with v prefix" and "calver without v prefix".

```console
$ gh release list | cut -f 1
v1.1.2
v1.1.1
2023.05.1
2023.05.0
v1.1.0
v1.0.1
2023.03.1
2023.03.0
v1.0.0
2023.02.0
v0.1.0
```

At this time, tagpr may misidentify calver as semver.

If tagpr could determine the `vPrefix` setting more strictly, it would avoid the misidentification, at least in my environment.

I hope you will consider this change.