### PR TITLE
Fix latest semver tag retrieval for first time setup

### DIFF
--- a/tagpr.go
+++ b/tagpr.go
@@ -42,10 +42,16 @@ type tagpr struct {
 
 func (tp *tagpr) latestSemverTag() string {
 	vers := (&gitsemvers.Semvers{GitPath: tp.gitPath}).VersionStrings()
-	vPrefix := (tp.cfg.vPrefix != nil && *tp.cfg.vPrefix)
-	for _, v := range vers {
-		if strings.HasPrefix(v, "v") == vPrefix {
-			return v
+	if tp.cfg.vPrefix != nil {
+		for _, v := range vers {
+			if strings.HasPrefix(v, "v") == *tp.cfg.vPrefix {
+				return v
+			}
+		}
+	} else {
+		// When vPrefix is not defined (i.e. first time tagpr setup), just return the first value.
+		if len(vers) > 0 {
+			return vers[0]
 		}
 	}
 	return ""

--- a/tagpr_test.go
+++ b/tagpr_test.go
@@ -311,13 +311,16 @@ func TestGeneratenNextLabels(t *testing.T) {
 }
 
 func TestLatestSemverTag(t *testing.T) {
+	vPrefixTrue := true
+	vPrefixFalse := false
 	tests := []struct {
 		name    string
-		vPrefix bool
+		vPrefix *bool
 		wantVer bool
 	}{
-		{"github.com/Songmu/tagpr has a semver tag with 'v' prefix", true, true},
-		{"github.com/Songmu/tagpr has no semver tag without 'v' prefix", false, false},
+		{"github.com/Songmu/tagpr has a semver tag with 'v' prefix", &vPrefixTrue, true},
+		{"github.com/Songmu/tagpr has no semver tag without 'v' prefix", &vPrefixFalse, false},
+		{"github.com/Songmu/tagpr returns the first tag when no config exists", nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -329,7 +332,7 @@ func TestLatestSemverTag(t *testing.T) {
 				return
 			}
 			tp.cfg = &config{
-				vPrefix: &tt.vPrefix,
+				vPrefix: tt.vPrefix,
 			}
 			got := tp.latestSemverTag()
 			if (got != "") != tt.wantVer {


### PR DESCRIPTION
I think tagpr v1.1.3 has a breaking change; when Songmu/tagpr is first setup, the Semver tag retrieval fails and returns `""` .

For example, the hatenablog-workflows repository which already has some tags tried to setup tagpr but ended up with the following Pull Request:
- https://github.com/hatena/hatenablog-workflows/pull/33 
  - As you can see in the changelog, tapr mistakes the current version as v0.0.0 https://github.com/hatena/hatenablog-workflows/pull/33/commits/ac48399e4862c1bbf13e4b02ea914640697dce44

This is probably because of https://github.com/Songmu/tagpr/pull/159 ; once you setup `.tagpr` file manually it works, but first time setup there is no `.tagpr` so `latestSemverTag` fails.
