### PR TITLE
update: added configuration of Github Enteprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Label of major update targets. Default is [major]
 ### tagpr.minorLabels (Optional)
 Label of minor update targets. Default is [minor]
 
-## GitHub Enterprise Server
-If you are using GitHub Enterprise Server, use `GH_ENTERPRISE_TOKEN` instead of `GITHUB_TOKEN`.
+## GitHub Enterprise
+If you are using GitHub Enterprise, use `GH_ENTERPRISE_TOKEN` instead of `GITHUB_TOKEN`.
 
 ```yaml
 - uses: Songmu/tagpr@v1

--- a/README.md
+++ b/README.md
@@ -128,6 +128,15 @@ Label of major update targets. Default is [major]
 ### tagpr.minorLabels (Optional)
 Label of minor update targets. Default is [minor]
 
+## GitHub Enterprise Server
+If you are using GitHub Enterprise Server, use `GH_ENTERPRISE_TOKEN` instead of `GITHUB_TOKEN`.
+
+```yaml
+- uses: Songmu/tagpr@v1
+  env:
+    GH_ENTERPRISE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ## Outputs for GitHub Actions
 
 The tagpr produces output to be used in conjunction with subsequent GitHub Actions jobs.


### PR DESCRIPTION
## Summary
Hi @Songmu 

I added a note to the README that if you are using GitHub Enterprise (Server), you need to use `GH_ENTERPRISE_TOKEN` instead of `GITHUB_TOKEN`.

## Background
I try to use `tagpr` on GitHub Enterprise (Server), but occurred the bellow error.
![image](https://github.com/Songmu/tagpr/assets/29038315/f5a824b3-5cb1-415a-a409-7367e8e0c6c1)

This error occurred by Songmu/gitconfig ([source code](https://github.com/Songmu/gitconfig/blob/c9eca57482f95e68b455581f94c1b822e2d3b057/special.go#L52)). Further investigation revealed that it was caused by cli/go-gh, which is used internally.
https://github.com/cli/go-gh/blob/debe718854c4ef26135c2348fd91db360fe5bae8/pkg/auth/auth.go#L62-L92

Ideally, this should be handled by `GITHUB_TOKEN`, but as a temporary solution, I updated README.