### PR TITLE
Add showGHError()

### DIFF
--- a/util.go
+++ b/util.go
@@ -3,6 +3,9 @@ package tagpr
 import (
 	"fmt"
 	"os"
+	"strings"
+
+	"github.com/google/go-github/v57/github"
 )
 
 func exists(filename string) bool {
@@ -27,4 +30,22 @@ func setOutput(name, value string) error {
 
 	_, err = f.WriteString(fmt.Sprintf("%s=%s\n", name, value))
 	return err
+}
+
+func showGHError(err error, resp *github.Response) {
+	title := "failed to request GitHub API"
+	message := err.Error()
+	if resp != nil {
+		respInfo := []string{
+			fmt.Sprintf("status=%d", resp.StatusCode),
+		}
+		for name, values := range resp.Header {
+			if strings.HasPrefix(strings.ToLower(name), "x-ratelimit") {
+				respInfo = append(respInfo, fmt.Sprintf("%s=%v", name, values))
+			}
+		}
+		message += " " + strings.Join(respInfo, ",")
+	}
+	// https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+	fmt.Printf("::error title=%s::%s\n", title, message)
 }

--- a/util.go
+++ b/util.go
@@ -45,7 +45,7 @@ func showGHError(err error, resp *github.Response) {
 				respInfo = append(respInfo, fmt.Sprintf("%s:%s", n, resp.Header.Get(name)))
 			}
 		}
-		message += " " + strings.Join(respInfo, ",")
+		message += " " + strings.Join(respInfo, ", ")
 	}
 	// https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
 	fmt.Printf("::error title=%s::%s\n", title, message)

--- a/util.go
+++ b/util.go
@@ -37,11 +37,12 @@ func showGHError(err error, resp *github.Response) {
 	message := err.Error()
 	if resp != nil {
 		respInfo := []string{
-			fmt.Sprintf("status=%d", resp.StatusCode),
+			fmt.Sprintf("status:%d", resp.StatusCode),
 		}
-		for name, values := range resp.Header {
-			if strings.HasPrefix(strings.ToLower(name), "x-ratelimit") {
-				respInfo = append(respInfo, fmt.Sprintf("%s=%v", name, values))
+		for name := range resp.Header {
+			n := strings.ToLower(name)
+			if strings.HasPrefix(n, "x-ratelimit") || n == "x-github-request-id" || n == "retry-after" {
+				respInfo = append(respInfo, fmt.Sprintf("%s:%s", n, resp.Header.Get(name)))
 			}
 		}
 		message += " " + strings.Join(respInfo, ",")


### PR DESCRIPTION
Show error messages with response metadata(status, x-ratelimit-*) by Action's error message format.

This is useful for troubleshooting.

See also https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message

### Example

<img width="795" alt="image" src="https://github.com/Songmu/tagpr/assets/67804/1bba567d-9144-4f5f-96bc-cf59b07aefdf">
