### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Songmu/tagpr@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
   tagpr:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.GH_PAT }}
     - uses: Songmu/tagpr@v1
@@ -150,7 +150,7 @@ The tagpr produces output to be used in conjunction with subsequent GitHub Actio
 It is useful to see if tag is available and to run tasks after release. The following is an example of running action-update-semver after release.
 
 ```yaml
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - id: tagpr
   uses: Songmu/tagpr@v1
   env:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+To enable pull requests to be created through GitHub Actions, check the "Allow GitHub Actions to create and approve pull requests" box in the "Workflow permissions" section under "Settings > Actions > General" in the repository where you are installing `tagpr`.
+
 If you do not want to use the token provided by GitHub Actions, do the following This is useful if you want to trigger another action with a tag.
 
 ref. <https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ on:
 jobs:
   tagpr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v3
     - uses: Songmu/tagpr@v1


### PR DESCRIPTION
Thank you for providing such a useful tool.
When I was installing it, I found some parts of the README that needed updating, so I created a pull request.

## permissions

The permissions given to the GITHUB_TOKEN for the job should be minimal.
In some articles, they choose the “Read and write permissions” button in the “Workflow permissions” section under “Settings > Actions > General”.
However, we can use `permissions` to modify the default permissions granted to the GITHUB_TOKEN.
ref: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions

## Additional setting

After setting `permissions`, there is one more setting required to run tagpr.
For this reason, I propose adding this setting to the README.

Here is final minimum setting for running tagpr:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/231349a0-b53a-4439-9584-6c6d853a26cd">

## actions/checkout

To prevent the following warning, I propose using newer version.
`The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3.`
