### PR TITLE
Retry when "Secondary rate limit" error occurs in GitHub API

### DIFF
--- a/config.go
+++ b/config.go
@@ -224,7 +224,7 @@ func (cfg *config) initializeFile() error {
 	return nil
 }
 
-func (cfg *config) SetRelaseBranch(br string) error {
+func (cfg *config) SetReleaseBranch(br string) error {
 	if err := cfg.set(configReleaseBranch, br); err != nil {
 		return err
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -24,7 +24,7 @@ func TestConfig(t *testing.T) {
 	if e, g := "", cfg.ReleaseBranch(); e != g {
 		t.Errorf("got: %s, expext: %s", g, e)
 	}
-	if err := cfg.SetRelaseBranch("main"); err != nil {
+	if err := cfg.SetReleaseBranch("main"); err != nil {
 		t.Error(err)
 	}
 	if e, g := "main", cfg.ReleaseBranch(); e != g {

--- a/github.go
+++ b/github.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/Songmu/gitconfig"
+	"github.com/gofri/go-github-ratelimit/github_ratelimit"
 	"github.com/google/go-github/v57/github"
 	"golang.org/x/oauth2"
 )
@@ -20,7 +21,11 @@ func ghClient(ctx context.Context, token, host string) (*github.Client, error) {
 	}
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	oauthClient := oauth2.NewClient(ctx, ts)
-	client := github.NewClient(oauthClient)
+	rateLimiter, err := github_ratelimit.NewRateLimitWaiterClient(oauthClient.Transport)
+	if err != nil {
+		return nil, err
+	}
+	client := github.NewClient(rateLimiter)
 
 	if host != "" && host != "github.com" {
 		// ref. https://github.com/google/go-github/issues/958

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Songmu/gh2changelog v0.0.5
 	github.com/Songmu/gitconfig v0.2.0
 	github.com/Songmu/gitsemvers v0.0.3
+	github.com/gofri/go-github-ratelimit v1.1.0
 	github.com/google/go-github/v57 v57.0.0
 	github.com/saracen/walker v0.1.3
 	golang.org/x/oauth2 v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn
 github.com/goccy/go-yaml v1.9.5/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
 github.com/goccy/go-yaml v1.11.2 h1:joq77SxuyIs9zzxEjgyLBugMQ9NEgTWxXfz2wVqwAaQ=
 github.com/goccy/go-yaml v1.11.2/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
+github.com/gofri/go-github-ratelimit v1.1.0 h1:ijQ2bcv5pjZXNil5FiwglCg8wc9s8EgjTmNkqjw8nuk=
+github.com/gofri/go-github-ratelimit v1.1.0/go.mod h1:OnCi5gV+hAG/LMR7llGhU7yHt44se9sYgKPnafoL7RY=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=

--- a/semver.go
+++ b/semver.go
@@ -34,9 +34,9 @@ func (sv *semv) GuessNext(labels []string) *semv {
 	var isMajor, isMinor bool
 	for _, l := range labels {
 		switch l {
-		case autoLableName + ":major", autoLableName + "/major":
+		case autoLabelName + ":major", autoLabelName + "/major":
 			isMajor = true
-		case autoLableName + ":minor", autoLableName + "/minor":
+		case autoLabelName + ":minor", autoLabelName + "/minor":
 			isMinor = true
 		}
 	}

--- a/tagpr.go
+++ b/tagpr.go
@@ -149,7 +149,7 @@ func (tp *tagpr) Run(ctx context.Context) error {
 		if releaseBranch == "" {
 			releaseBranch = defaultReleaseBranch
 		}
-		if err := tp.cfg.SetRelaseBranch(releaseBranch); err != nil {
+		if err := tp.cfg.SetReleaseBranch(releaseBranch); err != nil {
 			return err
 		}
 	}

--- a/tagpr.go
+++ b/tagpr.go
@@ -27,7 +27,7 @@ const (
 	defaultReleaseBranch = "main"
 	autoCommitMessage    = "[tagpr] prepare for the next release"
 	autoChangelogMessage = "[tagpr] update CHANGELOG.md"
-	autoLableName        = "tagpr"
+	autoLabelName        = "tagpr"
 	branchPrefix         = "tagpr-from-"
 )
 
@@ -111,7 +111,7 @@ func isTagPR(pr *github.PullRequest) bool {
 		return false
 	}
 	for _, label := range pr.Labels {
-		if label.GetName() == autoLableName {
+		if label.GetName() == autoLabelName {
 			return true
 		}
 	}
@@ -473,7 +473,7 @@ OUT:
 			showGHError(err, resp)
 			return err
 		}
-		addingLabels = append(addingLabels, autoLableName)
+		addingLabels = append(addingLabels, autoLabelName)
 		_, resp, err = tp.gh.Issues.AddLabelsToIssue(
 			ctx, tp.owner, tp.repo, *pr.Number, addingLabels)
 		if err != nil {


### PR DESCRIPTION
fixes #170 

## Problem to be solved

When using `secret.GITHUB_TOKEN` as a token to call GitHub API, “Secondary rate limit” error occurred frequently and the process stopped there.

## Solution to the problem

If a “Secondary rate limit” error occurs, wait for a certain period of time and retry according to the response header.
Use [go-github-ratelimit](https://github.com/gofri/go-github-ratelimit/tree/main) for retry mechanism.

## Test repository

I ran tagpr 10 times with the following repositories and the process was completed successfully without rate limit error.
https://github.com/snaka/tagpr-err-reproduce-with-debug/actions/runs/10957866785

Before the fix, the error occurred frequently (3 times in 12 tries) as follows
https://github.com/snaka/tagpr-err-reproduce/actions/runs/10956692059/job/30423254520


