### PR TITLE
Get the config file path from the environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ If you are using GitHub Enterprise, use `GH_ENTERPRISE_TOKEN` instead of `GITHUB
     GH_ENTERPRISE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+## Inputs for GitHub Actions
+
+### config (Optional)
+A path to the tagpr configuration file.
+If not specified, it will be ".tagpr" in the repository root.
+
 ## Outputs for GitHub Actions
 
 The tagpr produces output to be used in conjunction with subsequent GitHub Actions jobs.

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: "A version to install tagpr"
     required: false
     default: "v1.4.3"
+  config:
+    description: "A path to the tagpr configuration file"
+    required: false
 outputs:
   tag:
     description: "The semver tag, which is output only when the tagpr has tagged"
@@ -25,6 +28,8 @@ runs:
       curl -sfL https://raw.githubusercontent.com/Songmu/tagpr/main/install.sh | sh -s -- -b "$TEMP_PATH" "${{ inputs.version }}" 2>&1
       tagpr
     shell: bash
+    env:
+      TAGPR_CONFIG_FILE: ${{ inputs.config }}
 branding:
   icon: 'git-pull-request'
   color: 'blue'

--- a/config.go
+++ b/config.go
@@ -53,6 +53,7 @@ const (
 `
 	defaultMajorLabels  = "major"
 	defaultMinorLabels  = "minor"
+	envConfigFile       = "TAGPR_CONFIG_FILE"
 	envReleaseBranch    = "TAGPR_RELEASE_BRANCH"
 	envVersionFile      = "TAGPR_VERSION_FILE"
 	envVPrefix          = "TAGPR_VPREFIX"
@@ -89,9 +90,13 @@ type config struct {
 }
 
 func newConfig(gitPath string) (*config, error) {
+	var conf = defaultConfigFile
+	if cf := os.Getenv(envConfigFile); cf != "" {
+		conf = cf
+	}
 	cfg := &config{
-		conf:      defaultConfigFile,
-		gitconfig: &gitconfig.Config{GitPath: gitPath, File: defaultConfigFile},
+		conf:      conf,
+		gitconfig: &gitconfig.Config{GitPath: gitPath, File: conf},
 	}
 	err := cfg.Reload()
 	return cfg, err


### PR DESCRIPTION
You can specify the `.tagpr` file path from the GitHub Actions workflow file.

```yml
# Example
- uses: Songmu/tagpr@v1
  with:
    config: .github/tagpr
```