### PR TITLE
Use `releaseBranch` variable instead of the hard-coded "main" in `git log` command

### DIFF
--- a/tagpr.go
+++ b/tagpr.go
@@ -354,7 +354,7 @@ OUT:
 
 	// cherry-pick if the remote branch is exists and changed
 	// XXX: Do I need to apply merge commits too?
-	//     (We ommited merge commits for now, because if we cherry-pick them, we need to add options like "-m 1".
+	//     (We omitted merge commits for now, because if we cherry-pick them, we need to add options like "-m 1".
 	out, _, err := tp.c.Git("log", "--no-merges", "--pretty=format:%h %s",
 		fmt.Sprintf("%s..%s/%s", releaseBranch, tp.remoteName, rcBranch))
 	if err == nil {

--- a/tagpr.go
+++ b/tagpr.go
@@ -355,8 +355,8 @@ OUT:
 	// cherry-pick if the remote branch is exists and changed
 	// XXX: Do I need to apply merge commits too?
 	//     (We ommited merge commits for now, because if we cherry-pick them, we need to add options like "-m 1".
-	out, _, err := tp.c.Git(
-		"log", "--no-merges", "--pretty=format:%h %s", "main.."+tp.remoteName+"/"+rcBranch)
+	out, _, err := tp.c.Git("log", "--no-merges", "--pretty=format:%h %s",
+		fmt.Sprintf("%s..%s/%s", releaseBranch, tp.remoteName, rcBranch))
 	if err == nil {
 		var cherryPicks []string
 		for _, line := range strings.Split(out, "\n") {


### PR DESCRIPTION
This PR replaces a hard-coded main branch name, "main", with the `releaseBranch` variable in a git command in `tagpr.go`.

With the original implementation, when a release branch name different from "main" (e.g., "master" or "develop") is specified in the `.tagpr` config file, we encounter the following error during the execution of the `Songmu/tagpr@v1` action:

```
...
Switched to a new branch 'tagpr-from-v1.24.0'
git [add -f .tagpr]
git [commit --allow-empty -am [tagpr] prepare for the next release]
[tagpr-from-v1.24.0 b505e8d25] [tagpr] prepare for the next release

git [log --no-merges --pretty=format:%h %s main..origin/tagpr-from-v1.24.0]
fatal: ambiguous argument 'main..origin/tagpr-from-v1.24.0': unknown revision or path not in the working tree.  👈
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

Such a `git log ...` command error is currently ignored and results in an empty diff ("What's Changed" section) in the automated pull request as follows:
![image](https://github.com/user-attachments/assets/0f1fdf99-e988-4bb5-aeb3-4ff1684dc343)

This PR corrects the git log command so that tagpr successfully retrieves non-merge commits even when the name of the release branch is anything other than "main". 

