### PR TITLE
versionfile.go: omit .github directory from processing

### DIFF
--- a/versionfile.go
+++ b/versionfile.go
@@ -34,6 +34,8 @@ var (
 		// The directory for storing python test code, but it may be inappropriate to omit this directory
 		// uniformly because it may be used by test libraries for other languages.
 		"tests": true,
+		// .github is omitted because it is a directory for GitHub
+		".github": true,
 	}
 	skipFiles = map[string]bool{
 		"requirements.txt":  true,


### PR DESCRIPTION
Hi!

tagpr detects .github/workflows/*.yml as a version file.
See https://github.com/fujiwara/lambroll/pull/465/files

However, it is unlikely that workflow files are version files.

This PR adds the `.github` directory into skip directories.