### PR TITLE
Allow specifying tagpr labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ Pull request template text in go template format
 GitHub Release creation behavior after tagging `[true, draft, false]`  
 If this value is not set, the release is to be created.
 
+### tagpr.labelName (Optional)
+Label name for the pull request. Default is tagpr
+
 ### tagpr.majorLabels (Optional)
 Label of major update targets. Default is [major]
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ If this value is not set, the release is to be created.
 ### tagpr.labelName (Optional)
 Label name for the pull request. Default is tagpr
 
+### tagpr.useCustomLabels (Optional)
+Flag whether or not to use custom labels for major and minor updates.
+If true, the majorLabels and minorLabels are used.
+Default is false, and be used tagpr:major and tagpr:minor
+
 ### tagpr.majorLabels (Optional)
 Label of major update targets. Default is [major]
 

--- a/config.go
+++ b/config.go
@@ -57,6 +57,7 @@ const (
 #
 [tagpr]
 `
+	defaultLabelName    = "tagpr"
 	defaultMajorLabels  = "major"
 	defaultMinorLabels  = "minor"
 	defaultCommitPrefix = "[tagpr]"
@@ -69,6 +70,7 @@ const (
 	envTemplate         = "TAGPR_TEMPLATE"
 	envTemplateText     = "TAGPR_TEMPLATE_TEXT"
 	envRelease          = "TAGPR_RELEASE"
+	envLabelName        = "TAGPR_LABEL_NAME"
 	envMajorLabels      = "TAGPR_MAJOR_LABELS"
 	envMinorLabels      = "TAGPR_MINOR_LABELS"
 	envCommitPrefix     = "TAGPR_COMMIT_PREFIX"
@@ -80,6 +82,7 @@ const (
 	configTemplate      = "tagpr.template"
 	configTemplateText  = "tagpr.templateText"
 	configRelease       = "tagpr.release"
+	configLabelName     = "tagpr.labelName"
 	configMajorLabels   = "tagpr.majorLabels"
 	configMinorLabels   = "tagpr.minorLabels"
 	configCommitPrefix  = "tagpr.commitPrefix"
@@ -94,6 +97,7 @@ type config struct {
 	release       *string
 	vPrefix       *bool
 	changelog     *bool
+	labelName     *string
 	majorLabels   *string
 	minorLabels   *string
 	commitPrefix  *string
@@ -193,6 +197,17 @@ func (cfg *config) Reload() error {
 		rel, err := cfg.gitconfig.Get(configRelease)
 		if err == nil {
 			cfg.release = github.String(rel)
+		}
+	}
+
+	if label := os.Getenv(envLabelName); label != "" {
+		cfg.labelName = github.String(label)
+	} else {
+		label, err := cfg.gitconfig.Get(configLabelName)
+		if err == nil {
+			cfg.labelName = github.String(label)
+		} else {
+			cfg.labelName = github.String(defaultLabelName)
 		}
 	}
 
@@ -330,6 +345,10 @@ func (cfg *config) Release() bool {
 
 func (cfg *config) ReleaseDraft() bool {
 	return strings.ToLower(stringify(cfg.release)) == "draft"
+}
+
+func (cfg *config) LabelName() string {
+	return stringify(cfg.labelName)
 }
 
 func (cfg *config) MajorLabels() []string {

--- a/config.go
+++ b/config.go
@@ -46,6 +46,9 @@ const (
 #       GitHub Release creation behavior after tagging [true, draft, false]
 #       If this value is not set, the release is to be created.
 #
+#  tagpr.labelName (Optional)
+#       Label name for the pull request. Default is tagpr
+#
 #   tagpr.majorLabels (Optional)
 #       Label of major update targets. Default is [major]
 #

--- a/config.go
+++ b/config.go
@@ -60,50 +60,53 @@ const (
 #
 [tagpr]
 `
-	defaultLabelName    = "tagpr"
-	defaultMajorLabels  = "major"
-	defaultMinorLabels  = "minor"
-	defaultCommitPrefix = "[tagpr]"
-	envConfigFile       = "TAGPR_CONFIG_FILE"
-	envReleaseBranch    = "TAGPR_RELEASE_BRANCH"
-	envVersionFile      = "TAGPR_VERSION_FILE"
-	envVPrefix          = "TAGPR_VPREFIX"
-	envChangelog        = "TAGPR_CHANGELOG"
-	envCommand          = "TAGPR_COMMAND"
-	envTemplate         = "TAGPR_TEMPLATE"
-	envTemplateText     = "TAGPR_TEMPLATE_TEXT"
-	envRelease          = "TAGPR_RELEASE"
-	envLabelName        = "TAGPR_LABEL_NAME"
-	envMajorLabels      = "TAGPR_MAJOR_LABELS"
-	envMinorLabels      = "TAGPR_MINOR_LABELS"
-	envCommitPrefix     = "TAGPR_COMMIT_PREFIX"
-	configReleaseBranch = "tagpr.releaseBranch"
-	configVersionFile   = "tagpr.versionFile"
-	configVPrefix       = "tagpr.vPrefix"
-	configChangelog     = "tagpr.changelog"
-	configCommand       = "tagpr.command"
-	configTemplate      = "tagpr.template"
-	configTemplateText  = "tagpr.templateText"
-	configRelease       = "tagpr.release"
-	configLabelName     = "tagpr.labelName"
-	configMajorLabels   = "tagpr.majorLabels"
-	configMinorLabels   = "tagpr.minorLabels"
-	configCommitPrefix  = "tagpr.commitPrefix"
+	defaultLabelName      = "tagpr"
+	defaultMajorLabels    = "major"
+	defaultMinorLabels    = "minor"
+	defaultCommitPrefix   = "[tagpr]"
+	envConfigFile         = "TAGPR_CONFIG_FILE"
+	envReleaseBranch      = "TAGPR_RELEASE_BRANCH"
+	envVersionFile        = "TAGPR_VERSION_FILE"
+	envVPrefix            = "TAGPR_VPREFIX"
+	envChangelog          = "TAGPR_CHANGELOG"
+	envCommand            = "TAGPR_COMMAND"
+	envTemplate           = "TAGPR_TEMPLATE"
+	envTemplateText       = "TAGPR_TEMPLATE_TEXT"
+	envRelease            = "TAGPR_RELEASE"
+	envLabelName          = "TAGPR_LABEL_NAME"
+	envUseCustomLabels    = "TAGPR_USE_CUSTOM_LABELS"
+	envMajorLabels        = "TAGPR_MAJOR_LABELS"
+	envMinorLabels        = "TAGPR_MINOR_LABELS"
+	envCommitPrefix       = "TAGPR_COMMIT_PREFIX"
+	configReleaseBranch   = "tagpr.releaseBranch"
+	configVersionFile     = "tagpr.versionFile"
+	configVPrefix         = "tagpr.vPrefix"
+	configChangelog       = "tagpr.changelog"
+	configCommand         = "tagpr.command"
+	configTemplate        = "tagpr.template"
+	configTemplateText    = "tagpr.templateText"
+	configRelease         = "tagpr.release"
+	configLabelName       = "tagpr.labelName"
+	configUseCustomLabels = "tagpr.useCustomLabels"
+	configMajorLabels     = "tagpr.majorLabels"
+	configMinorLabels     = "tagpr.minorLabels"
+	configCommitPrefix    = "tagpr.commitPrefix"
 )
 
 type config struct {
-	releaseBranch *string
-	versionFile   *string
-	command       *string
-	template      *string
-	templateText  *string
-	release       *string
-	vPrefix       *bool
-	changelog     *bool
-	labelName     *string
-	majorLabels   *string
-	minorLabels   *string
-	commitPrefix  *string
+	releaseBranch  *string
+	versionFile    *string
+	command        *string
+	template       *string
+	templateText   *string
+	release        *string
+	vPrefix        *bool
+	changelog      *bool
+	labelName      *string
+	useCustomLabel *bool
+	majorLabels    *string
+	minorLabels    *string
+	commitPrefix   *string
 
 	conf      string
 	gitconfig *gitconfig.Config
@@ -222,6 +225,19 @@ func (cfg *config) Reload() error {
 			cfg.majorLabels = github.String(major)
 		} else {
 			cfg.majorLabels = github.String(defaultMajorLabels)
+		}
+	}
+
+	if useCustomLabel := os.Getenv(envUseCustomLabels); useCustomLabel != "" {
+		b, err := strconv.ParseBool(useCustomLabel)
+		if err != nil {
+			return err
+		}
+		cfg.useCustomLabel = github.Bool(b)
+	} else {
+		b, err := cfg.gitconfig.Bool(configUseCustomLabels)
+		if err == nil {
+			cfg.useCustomLabel = github.Bool(b)
 		}
 	}
 
@@ -364,6 +380,16 @@ func (cfg *config) MajorLabels() []string {
 	return labels
 }
 
+func (cfg *config) MajorLabel() string {
+	if cfg.useCustomLabel != nil && *cfg.useCustomLabel {
+		if labels := cfg.MajorLabels(); labels != nil {
+			return labels[0]
+		}
+	}
+
+	return defaultLabelName + ":major"
+}
+
 func (cfg *config) MinorLabels() []string {
 	labels := strings.Split(stringify(cfg.minorLabels), ",")
 
@@ -372,6 +398,16 @@ func (cfg *config) MinorLabels() []string {
 	}
 
 	return labels
+}
+
+func (cfg *config) MinorLabel() string {
+	if cfg.useCustomLabel != nil && *cfg.useCustomLabel {
+		if labels := cfg.MinorLabels(); labels != nil {
+			return labels[0]
+		}
+	}
+
+	return defaultLabelName + ":minor"
 }
 
 func (cfg *config) CommitPrefix() string {

--- a/config.go
+++ b/config.go
@@ -49,6 +49,11 @@ const (
 #  tagpr.labelName (Optional)
 #       Label name for the pull request. Default is tagpr
 #
+#   tagpr.useCustomLabels (Optional)
+#       Flag whether or not to use custom labels for major and minor updates.
+#       If true, the majorLabels and minorLabels are used.
+#       Default is false, and be used tagpr:major and tagpr:minor
+#
 #   tagpr.majorLabels (Optional)
 #       Label of major update targets. Default is [major]
 #

--- a/config_test.go
+++ b/config_test.go
@@ -42,7 +42,13 @@ func TestConfig(t *testing.T) {
 	if e, g := []string{"major"}, cfg.MajorLabels(); !reflect.DeepEqual(e, g) {
 		t.Errorf("got: %s, expext: %s", g, e)
 	}
+	if e, g := "tagpr:major", cfg.MajorLabel(); e != g {
+		t.Errorf("got: %s, expext: %s", g, e)
+	}
 	if e, g := []string{"minor"}, cfg.MinorLabels(); !reflect.DeepEqual(e, g) {
+		t.Errorf("got: %s, expext: %s", g, e)
+	}
+	if e, g := "tagpr:minor", cfg.MinorLabel(); e != g {
 		t.Errorf("got: %s, expext: %s", g, e)
 	}
 	if e, g := "[tagpr]", cfg.CommitPrefix(); !reflect.DeepEqual(e, g) {

--- a/config_test.go
+++ b/config_test.go
@@ -36,6 +36,9 @@ func TestConfig(t *testing.T) {
 	if e, g := "", cfg.VersionFile(); e != g {
 		t.Errorf("got: %s, expext: %s", g, e)
 	}
+	if e, g := "tagpr", cfg.LabelName(); e != g {
+		t.Errorf("got: %s, expext: %s", g, e)
+	}
 	if e, g := []string{"major"}, cfg.MajorLabels(); !reflect.DeepEqual(e, g) {
 		t.Errorf("got: %s, expext: %s", g, e)
 	}

--- a/semver.go
+++ b/semver.go
@@ -34,9 +34,9 @@ func (sv *semv) GuessNext(labels []string) *semv {
 	var isMajor, isMinor bool
 	for _, l := range labels {
 		switch l {
-		case autoLabelName + ":major", autoLabelName + "/major":
+		case defaultLabelName + ":major", defaultLabelName + "/major":
 			isMajor = true
-		case autoLabelName + ":minor", autoLabelName + "/minor":
+		case defaultLabelName + ":minor", defaultLabelName + "/minor":
 			isMinor = true
 		}
 	}

--- a/semver.go
+++ b/semver.go
@@ -30,13 +30,13 @@ func (sv *semv) Tag() string {
 	return sv.Naked()
 }
 
-func (sv *semv) GuessNext(labels []string) *semv {
+func (sv *semv) GuessNext(labels []string, majorLabel string, minorLabel string) *semv {
 	var isMajor, isMinor bool
 	for _, l := range labels {
 		switch l {
-		case defaultLabelName + ":major", defaultLabelName + "/major":
+		case defaultLabelName + ":major", defaultLabelName + "/major", majorLabel:
 			isMajor = true
-		case defaultLabelName + ":minor", defaultLabelName + "/minor":
+		case defaultLabelName + ":minor", defaultLabelName + "/minor", minorLabel:
 			isMinor = true
 		}
 	}

--- a/tag.go
+++ b/tag.go
@@ -63,7 +63,7 @@ func (tp *tagpr) tagRelease(ctx context.Context, pr *github.PullRequest, currVer
 		for _, l := range pr.Labels {
 			labels = append(labels, l.GetName())
 		}
-		nextTag = currVer.GuessNext(labels).Tag()
+		nextTag = currVer.GuessNext(labels, tp.cfg.MajorLabel(), tp.cfg.MinorLabel()).Tag()
 	}
 	previousTag := &latestSemverTag
 	if *previousTag == "" {

--- a/tagpr.go
+++ b/tagpr.go
@@ -282,7 +282,7 @@ func (tp *tagpr) Run(ctx context.Context) error {
 			labels = append(labels, l.GetName())
 		}
 	}
-	nextVer := currVer.GuessNext(append(labels, nextLabels...))
+	nextVer := currVer.GuessNext(append(labels, nextLabels...), tp.cfg.MajorLabel(), tp.cfg.MinorLabel())
 	var addingLabels []string
 OUT:
 	for _, l := range nextLabels {
@@ -606,10 +606,10 @@ func (tp *tagpr) generatenNextLabels(prIssues []*github.Issue) []string {
 	}
 	var nextLabels []string
 	if nextMinor {
-		nextLabels = append(nextLabels, "tagpr:minor")
+		nextLabels = append(nextLabels, tp.cfg.MinorLabel())
 	}
 	if nextMajor {
-		nextLabels = append(nextLabels, "tagpr:major")
+		nextLabels = append(nextLabels, tp.cfg.MajorLabel())
 	}
 
 	return nextLabels


### PR DESCRIPTION
1. Change the PR label name

   ```ini
   [tagpr]
     labelName = original-label
   ```

   A label named `original-label`, will be added to PRs created by tagpr.
   When major or minor changes are detected,
   the labels will remain `tagpr:major` and `tagpr:minor` respectively.

2. Use the custom labels

   ```ini
   [tagpr]
     useCustomLabels = true
     majorLabels = major-label1,major-label2
     minorLabels = minor-label,minor-label2
   ```

   When major or minor changes are detected,
   the labels will be `major-label1` and `minor-label1` respectively.
   If the `majorLabels` or `minorLabels` is not set,
   the labels will remain `tagpr:major` and `tagpr:minor` respectively.

Closes #168