### PR TITLE
Fix 403 error by adding 'issues: write' permission to GitHub Actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
     - uses: actions/checkout@v4
     - uses: Songmu/tagpr@v1


### PR DESCRIPTION
This README update addresses a 403 error caused by insufficient permissions to create labels via GitHub Actions.

```
POST https://api.github.com/repos/monochromegane/kmeans/issues/1/labels: 403 You do not have permission to create labels on this repository. [{Resource:Repository Field:label Code:unauthorized Message:}]
Error: POST https://api.github.com/repos/monochromegane/kmeans/issues/1/labels: 403 You do not have permission to create labels on this repository. [{Resource:Repository Field:label Code:unauthorized Message:}] status:403, ...

Error: Process completed with exit code 1.
```

I believe that tagpr requires additional permissions to create labels via POST requests to issues.
In my repository, it started working correctly after adding the above permission setting.
If this fix is appropriate, please consider reflecting it in the README.


