### PR TITLE
Add docs about persist-credentials of actions/checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ jobs:
       issues: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: true
     - uses: Songmu/tagpr@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -166,6 +168,8 @@ It is useful to see if tag is available and to run tasks after release. The foll
 
 ```yaml
 - uses: actions/checkout@v4
+  with:
+    persist-credentials: true
 - id: tagpr
   uses: Songmu/tagpr@v1
   env:


### PR DESCRIPTION
For security reasons, it is recommended to set `persist-credentials: false` in actions/checkout unless it is explicitly required.
However, when using tagpr in combination with actions/checkout, it is necessary to set `persist-credentials: true`.

This requirement has now been explicitly documented in the README.