### PR TITLE
Reducing supply chain risk at actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
       cd "${GITHUB_WORKSPACE}" || exit 1
       TEMP_PATH="$(mktemp -d)"
       PATH="${TEMP_PATH}:$PATH"
-      curl -sfL https://raw.githubusercontent.com/Songmu/tagpr/main/install.sh | sh -s -- -b "$TEMP_PATH" "${{ inputs.version }}" 2>&1
+      curl -sfL https://raw.githubusercontent.com/Songmu/tagpr/v1.5.2/install.sh | sh -s -- -b "$TEMP_PATH" "${{ inputs.version }}" 2>&1
       tagpr
     shell: bash
     env:


### PR DESCRIPTION
In the current implementation of the action, even when we pin a specific version, the installer is still fetched from the `main` branch `HEAD`.

This behavior introduces a **significant supply chain security risk**, as it allows unreviewed or unintended changes in the main branch to be executed in user workflows.

To address this, I have modified the implementation to reduce this risk and ensure more predictable and secure behavior.