### PR TITLE
Improve the composite action security

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -17,4 +17,4 @@
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
-	versionFile = version.go,action.yml,action.yml # update version 2 times in action.yml
+	versionFile = version.go,action.yml

--- a/action.yml
+++ b/action.yml
@@ -25,11 +25,12 @@ runs:
       cd "${GITHUB_WORKSPACE}" || exit 1
       TEMP_PATH="$(mktemp -d)"
       PATH="${TEMP_PATH}:$PATH"
-      curl -sfL "https://raw.githubusercontent.com/Songmu/tagpr/${ACTION_REF}/install.sh" | sh -s -- -b "$TEMP_PATH" "${{ inputs.version }}" 2>&1
+      curl -sfL "https://raw.githubusercontent.com/Songmu/tagpr/${ACTION_REF}/install.sh" | sh -s -- -b "$TEMP_PATH" "$TAGPR_VERSION" 2>&1
       tagpr
     shell: bash
     env:
       ACTION_REF: ${{ github.action_ref }}
+      TAGPR_VERSION: ${{ inputs.version }}
       TAGPR_CONFIG_FILE: ${{ inputs.config }}
 branding:
   icon: 'git-pull-request'

--- a/action.yml
+++ b/action.yml
@@ -25,12 +25,12 @@ runs:
       cd "${GITHUB_WORKSPACE}" || exit 1
       TEMP_PATH="$(mktemp -d)"
       PATH="${TEMP_PATH}:$PATH"
-      curl -sfL "https://raw.githubusercontent.com/Songmu/tagpr/${ACTION_VERSION}/install.sh" | sh -s -- -b "$TEMP_PATH" "${{ inputs.version }}" 2>&1
+      curl -sfL "https://raw.githubusercontent.com/Songmu/tagpr/${ACTION_REF}/install.sh" | sh -s -- -b "$TEMP_PATH" "${{ inputs.version }}" 2>&1
       tagpr
     shell: bash
     env:
+      ACTION_REF: ${{ github.action_ref }}
       TAGPR_CONFIG_FILE: ${{ inputs.config }}
-      ACTION_VERSION: "v1.6.1"
 branding:
   icon: 'git-pull-request'
   color: 'blue'


### PR DESCRIPTION
1.  Use the executed composite action ref

    Follow the refs referenced from workflows.
    Users may use branch, tag, or hash.

    ```yml
    jobs:
      job:
        runs-on: Ubuntu-Latest
        steps:
          - uses: Songmu/tagpr@<ref>
    ```

2.  Use environment variables for the input

    GitHub Actions will replace the context with plain text. If users or contributors enter the malformed text, secrets might be exposed.

    ```yml
    # prevent this
    jobs:
      job:
        runs-on: Ubuntu-Latest
        steps:
          - uses: Songmu/tagpr@<ref>
            with:
              version: \" || rm -rf / \"
    ```