### PR TITLE
feat: add-post-version-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,10 @@ This is only a tagging convention, not how it is described in the version file.
 Flag whether or not changelog is added or changed during the release.
 
 ### tagpr.command (Optional)
-Command to change files just before release.
+Command to change files just before release and versioning.
+
+### tagpr.postVersionCommand (Optional)
+Command to change files just after versioning.
 
 ### tagpr.template (Optional)
 Pull request template file in go template format

--- a/config.go
+++ b/config.go
@@ -34,7 +34,10 @@ const (
 #       Flag whether or not changelog is added or changed during the release.
 #
 #   tagpr.command (Optional)
-#       Command to change files just before release.
+#       Command to change files just before release and versioning.
+#
+#   tagpr.postVersionCommand (Optional)
+#       Command to change files just after versioning.
 #
 #   tagpr.template (Optional)
 #       Pull request template file in go template format
@@ -57,46 +60,49 @@ const (
 #
 [tagpr]
 `
-	defaultMajorLabels  = "major"
-	defaultMinorLabels  = "minor"
-	defaultCommitPrefix = "[tagpr]"
-	envConfigFile       = "TAGPR_CONFIG_FILE"
-	envReleaseBranch    = "TAGPR_RELEASE_BRANCH"
-	envVersionFile      = "TAGPR_VERSION_FILE"
-	envVPrefix          = "TAGPR_VPREFIX"
-	envChangelog        = "TAGPR_CHANGELOG"
-	envCommand          = "TAGPR_COMMAND"
-	envTemplate         = "TAGPR_TEMPLATE"
-	envTemplateText     = "TAGPR_TEMPLATE_TEXT"
-	envRelease          = "TAGPR_RELEASE"
-	envMajorLabels      = "TAGPR_MAJOR_LABELS"
-	envMinorLabels      = "TAGPR_MINOR_LABELS"
-	envCommitPrefix     = "TAGPR_COMMIT_PREFIX"
-	configReleaseBranch = "tagpr.releaseBranch"
-	configVersionFile   = "tagpr.versionFile"
-	configVPrefix       = "tagpr.vPrefix"
-	configChangelog     = "tagpr.changelog"
-	configCommand       = "tagpr.command"
-	configTemplate      = "tagpr.template"
-	configTemplateText  = "tagpr.templateText"
-	configRelease       = "tagpr.release"
-	configMajorLabels   = "tagpr.majorLabels"
-	configMinorLabels   = "tagpr.minorLabels"
-	configCommitPrefix  = "tagpr.commitPrefix"
+	defaultMajorLabels       = "major"
+	defaultMinorLabels       = "minor"
+	defaultCommitPrefix      = "[tagpr]"
+	envConfigFile            = "TAGPR_CONFIG_FILE"
+	envReleaseBranch         = "TAGPR_RELEASE_BRANCH"
+	envVersionFile           = "TAGPR_VERSION_FILE"
+	envVPrefix               = "TAGPR_VPREFIX"
+	envChangelog             = "TAGPR_CHANGELOG"
+	envCommand               = "TAGPR_COMMAND"
+	envPostVersionCommand    = "TAGPR_POST_VERSION_COMMAND"
+	envTemplate              = "TAGPR_TEMPLATE"
+	envTemplateText          = "TAGPR_TEMPLATE_TEXT"
+	envRelease               = "TAGPR_RELEASE"
+	envMajorLabels           = "TAGPR_MAJOR_LABELS"
+	envMinorLabels           = "TAGPR_MINOR_LABELS"
+	envCommitPrefix          = "TAGPR_COMMIT_PREFIX"
+	configReleaseBranch      = "tagpr.releaseBranch"
+	configVersionFile        = "tagpr.versionFile"
+	configVPrefix            = "tagpr.vPrefix"
+	configChangelog          = "tagpr.changelog"
+	configCommand            = "tagpr.command"
+	configPostVersionCommand = "tagpr.postVersionCommand"
+	configTemplate           = "tagpr.template"
+	configTemplateText       = "tagpr.templateText"
+	configRelease            = "tagpr.release"
+	configMajorLabels        = "tagpr.majorLabels"
+	configMinorLabels        = "tagpr.minorLabels"
+	configCommitPrefix       = "tagpr.commitPrefix"
 )
 
 type config struct {
-	releaseBranch *string
-	versionFile   *string
-	command       *string
-	template      *string
-	templateText  *string
-	release       *string
-	vPrefix       *bool
-	changelog     *bool
-	majorLabels   *string
-	minorLabels   *string
-	commitPrefix  *string
+	releaseBranch      *string
+	versionFile        *string
+	command            *string
+	postVersionCommand *string
+	template           *string
+	templateText       *string
+	release            *string
+	vPrefix            *bool
+	changelog          *bool
+	majorLabels        *string
+	minorLabels        *string
+	commitPrefix       *string
 
 	conf      string
 	gitconfig *gitconfig.Config
@@ -166,6 +172,15 @@ func (cfg *config) Reload() error {
 		command, err := cfg.gitconfig.Get(configCommand)
 		if err == nil {
 			cfg.command = github.String(command)
+		}
+	}
+
+	if postCommand := os.Getenv(envPostVersionCommand); postCommand != "" {
+		cfg.postVersionCommand = github.String(postCommand)
+	} else {
+		postCommand, err := cfg.gitconfig.Get(configPostVersionCommand)
+		if err == nil {
+			cfg.postVersionCommand = github.String(postCommand)
 		}
 	}
 
@@ -306,6 +321,10 @@ func (cfg *config) VersionFile() string {
 
 func (cfg *config) Command() string {
 	return stringify(cfg.command)
+}
+
+func (cfg *config) PostVersionCommand() string {
+	return stringify(cfg.postVersionCommand)
 }
 
 func (cfg *config) Template() string {

--- a/tagpr.go
+++ b/tagpr.go
@@ -323,6 +323,18 @@ OUT:
 	}
 	tp.c.Git("add", "-f", tp.cfg.conf) // ignore any errors
 
+	if prog := tp.cfg.PostVersionCommand(); prog != "" {
+		var progArgs []string
+		if strings.ContainsAny(prog, " \n") {
+			progArgs = []string{"-c", prog}
+			prog = "sh"
+		}
+		tp.c.Cmd(prog, progArgs, map[string]string{
+			"TAGPR_CURRENT_VERSION": currVer.Tag(),
+			"TAGPR_NEXT_VERSION":    nextVer.Tag(),
+		})
+	}
+
 	const releaseYml = ".github/release.yml"
 	// TODO: It would be nice to be able to add an exclude setting even if release.yml already exists.
 	if !exists(releaseYml) {


### PR DESCRIPTION
This pull request introduces a new feature to support a `tagpr.postVersionCommand` configuration option, which allows users to specify a command to be executed after versioning during the release process. The changes encompass updates to the documentation, configuration handling, and implementation of the new command execution logic.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L124-R127): Added a description for the new `tagpr.postVersionCommand` configuration option, explaining its purpose and usage.

### Configuration Enhancements:
* `config.go`: 
  - Added support for the `tagpr.postVersionCommand` configuration in both environment variables (`envPostVersionCommand`) and Git config (`configPostVersionCommand`). [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R72) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R84)
  - Updated the `config` struct to include a new field, `postVersionCommand`, for storing the command.
  - Enhanced the `Reload` method to load the `postVersionCommand` from environment variables or Git config.
  - Added a new method, `PostVersionCommand`, to retrieve the `postVersionCommand` value.

### Implementation of Command Execution:
* [`tagpr.go`](diffhunk://#diff-00001cf4015c72d13b130feed633ea5ebfadd8df2f34ebac7de915f2a653210bR326-R337): Implemented logic to execute the `postVersionCommand` after versioning. If the command contains spaces or newlines, it is executed via `sh -c`. Environment variables `TAGPR_CURRENT_VERSION` and `TAGPR_NEXT_VERSION` are passed to the command for context.

Closes: #211 