### PR TITLE
fix: scope git log to tagPrefix path in monorepo mode

### DIFF
--- a/tagpr.go
+++ b/tagpr.go
@@ -101,8 +101,12 @@ func (tp *tagpr) getNextLabels(ctx context.Context, mergedFeatureHeadShas []stri
 
 	releaseBranch := tp.cfg.ReleaseBranch()
 
-	shasStr, _, err := tp.c.Git("log", "--pretty=format:%h", "--abbrev=7", "--no-merges", "--first-parent",
-		fmt.Sprintf("%s..%s/%s", fromCommitish, tp.remoteName, releaseBranch))
+	logArgs := []string{"log", "--pretty=format:%h", "--abbrev=7", "--no-merges", "--first-parent",
+		fmt.Sprintf("%s..%s/%s", fromCommitish, tp.remoteName, releaseBranch)}
+	if tp.normalizedTagPrefix != "" {
+		logArgs = append(logArgs, "--", strings.TrimSuffix(tp.normalizedTagPrefix, "/"))
+	}
+	shasStr, _, err := tp.c.Git(logArgs...)
 	if err != nil {
 		return []string{}, err
 	}
@@ -253,8 +257,12 @@ func (tp *tagpr) Run(ctx context.Context) error {
 		tp.setOutput("pull_request", string(b))
 		return nil
 	}
-	shasStr, _, err := tp.c.Git("log", "--merges", "--pretty=format:%P",
-		fmt.Sprintf("%s..%s/%s", fromCommitish, tp.remoteName, releaseBranch))
+	mergeLogArgs := []string{"log", "--merges", "--pretty=format:%P",
+		fmt.Sprintf("%s..%s/%s", fromCommitish, tp.remoteName, releaseBranch)}
+	if tp.normalizedTagPrefix != "" {
+		mergeLogArgs = append(mergeLogArgs, "--", strings.TrimSuffix(tp.normalizedTagPrefix, "/"))
+	}
+	shasStr, _, err := tp.c.Git(mergeLogArgs...)
 	if err != nil {
 		return err
 	}
@@ -441,8 +449,12 @@ func (tp *tagpr) Run(ctx context.Context) error {
 	// cherry-pick if the remote branch is exists and changed
 	// XXX: Do I need to apply merge commits too?
 	//     (We omitted merge commits for now, because if we cherry-pick them, we need to add options like "-m 1".
-	out, _, err := tp.c.Git("log", "--no-merges", "--pretty=format:%h %s",
-		fmt.Sprintf("%s..%s/%s", releaseBranch, tp.remoteName, rcBranch))
+	cherryLogArgs := []string{"log", "--no-merges", "--pretty=format:%h %s",
+		fmt.Sprintf("%s..%s/%s", releaseBranch, tp.remoteName, rcBranch)}
+	if tp.normalizedTagPrefix != "" {
+		cherryLogArgs = append(cherryLogArgs, "--", strings.TrimSuffix(tp.normalizedTagPrefix, "/"))
+	}
+	out, _, err := tp.c.Git(cherryLogArgs...)
 	if err == nil {
 		var cherryPicks []string
 		for line := range strings.SplitSeq(out, "\n") {


### PR DESCRIPTION
### Summary

Add path filtering for git log commands when `tagPrefix` is configured.
This ensures release PRs are only created when files under the tagPrefix directory are changed.

Fixes #273

### Motivation

When using `tagPrefix` for monorepo support (e.g., `modules/s3`), tagpr currently creates release PRs even when changes are made to unrelated modules (e.g., `modules/foo`).

This happens because the `git log` commands do not filter commits by path—they retrieve all commits in the range regardless of which files were changed.

### Changes

Add `-- <path>` argument to git log commands when `normalizedTagPrefix` is set:

1. **getNextLabels()** - Commit SHA retrieval for PR label extraction
2. **Run()** - Merge commit detection for changelog generation
3. **Run()** - Cherry-pick target detection

### Example

```go
// Before
shasStr, _, err := tp.c.Git("log", "--pretty=format:%h", ..., range)

// After
logArgs := []string{"log", "--pretty=format:%h", ..., range}
if tp.normalizedTagPrefix != "" {
    logArgs = append(logArgs, "--", strings.TrimSuffix(tp.normalizedTagPrefix, "/"))
}
shasStr, _, err := tp.c.Git(logArgs...)
```

### Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| Change in `modules/s3/` (target) | Release PR created | Release PR created |
| Change in `modules/foo/` (other) | Release PR created | No action |
| Change in `root.tf` | Release PR created | No action |

### Backward Compatibility

When `tagPrefix` is not set, behavior is identical to current version.
