### PR TITLE
fix: add check for both release.yml and release.yaml files

### DIFF
--- a/tagpr.go
+++ b/tagpr.go
@@ -349,8 +349,9 @@ func (tp *tagpr) Run(ctx context.Context) error {
 	}
 
 	const releaseYml = ".github/release.yml"
+	const releaseYaml = ".github/release.yaml"
 	// TODO: It would be nice to be able to add an exclude setting even if release.yml already exists.
-	if !exists(releaseYml) {
+	if !exists(releaseYml) && !exists(releaseYaml) {
 		if err := os.MkdirAll(filepath.Dir(releaseYml), 0755); err != nil {
 			return err
 		}


### PR DESCRIPTION
 - Check for both .`github/release.yml` and `.github/release.yaml` before auto-generating the release config file.
 - Previously, tagpr only checked for `.github/release.yml`, causing it to generate a duplicate file when `.github/release.yaml` already existed.