### PR TITLE
feat: add base_tag output for GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ The tagpr produces output to be used in conjunction with subsequent GitHub Actio
 
 - `pull_request`: Information of the pull request created by tagpr in JSON format
 - `tag`: Tag strings are output only if the tagpr has tagged
+- `base_tag`: The base semver tag for comparison, empty if no previous tag exists
 
 It is useful to see if tag is available and to run tasks after release. The following is an example of running action-update-semver after release.
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ outputs:
   pull_request:
     description: "Information of the pull request created by tagpr in JSON format"
     value: ${{ steps.tagpr.outputs.pull_request }}
+  base_tag:
+    description: "The base semver tag for comparison, empty if no previous tag exists"
+    value: ${{ steps.tagpr.outputs.base_tag }}
 runs:
   using: "composite"
   steps:

--- a/tagpr.go
+++ b/tagpr.go
@@ -194,6 +194,7 @@ func (tp *tagpr) Run(ctx context.Context) error {
 	changelogMessage := tp.cfg.CommitPrefix() + " " + autoChangelogMessage
 
 	latestSemverTag := tp.latestSemverTag()
+	tp.setOutput("base_tag", latestSemverTag)
 	currVerStr := latestSemverTag
 	fromCommitish := "refs/tags/" + currVerStr
 	if currVerStr == "" {


### PR DESCRIPTION
## Summary

This PR adds a new `base_tag` output that exposes the latest semver tag used as the comparison base for changelog generation.

## Motivation

While `tag` output provides the newly created tag, there is currently no way to retrieve the base tag (the previous release tag) in subsequent GitHub Actions steps. This information can be useful for:

- Generating release notes that reference the previous version
- Creating diff links between versions
- Custom automation that needs to know both the old and new versions

## Changes

- `tagpr.go`: Add `setOutput("base_tag", latestSemverTag)` to output the base tag
- `action.yml`: Declare `base_tag` in the outputs section
- `README.md`: Document the new output

## Behavior

- The `base_tag` is always output (on both PR creation/update and tag creation)
- On the first release (when no previous tag exists), it outputs an empty string
- Includes the tag prefix for monorepo setups (e.g., `tools/v1.2.3`)

## Example Usage

### Preview changes since last release (before merge)

The `base_tag` is available even before the release PR is merged, so you can preview what will be included in the next release:

```yaml
- uses: Songmu/tagpr@v1
  id: tagpr
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

- name: Show changes since last release
  if: steps.tagpr.outputs.base_tag != ''
  run: git diff ${{ steps.tagpr.outputs.base_tag }} HEAD
```

### Compare changes between releases (after merge)

```yaml
- uses: Songmu/tagpr@v1
  id: tagpr
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

- name: Show diff between releases
  if: steps.tagpr.outputs.base_tag != '' && steps.tagpr.outputs.tag != ''
  run: git diff ${{ steps.tagpr.outputs.base_tag }} ${{ steps.tagpr.outputs.tag }}
```

### Pass both versions to another action

```yaml
- uses: Songmu/tagpr@v1
  id: tagpr
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

- uses: some-action/release-notes@v1
  if: steps.tagpr.outputs.base_tag != '' && steps.tagpr.outputs.tag != ''
  with:
    base: ${{ steps.tagpr.outputs.base_tag }}
    head: ${{ steps.tagpr.outputs.tag }}
```