### PR TITLE
Add fixedMajorVersion option for multiple major version support

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -233,3 +233,48 @@ func TestConfigCalendarVersioningRejectsMajorMinorFromEnv(t *testing.T) {
 		t.Error("expected error for MAJOR token in env")
 	}
 }
+
+func TestFixedMajorVersion(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    *uint64
+		wantErr bool
+	}{
+		{"1", ptr(uint64(1)), false},
+		{"10", ptr(uint64(10)), false},
+		{"v1", ptr(uint64(1)), false},
+		{"v10", ptr(uint64(10)), false},
+		{"", nil, false},
+		{"abc", nil, true},
+		{"v", nil, true},
+		{"-1", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			cfg := &config{
+				fixedMajorVersion: &tt.input,
+			}
+			got, err := cfg.FixedMajorVersion()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FixedMajorVersion(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("FixedMajorVersion(%q) = %v, want nil", tt.input, *got)
+				}
+			} else {
+				if got == nil {
+					t.Errorf("FixedMajorVersion(%q) = nil, want %v", tt.input, *tt.want)
+				} else if *got != *tt.want {
+					t.Errorf("FixedMajorVersion(%q) = %v, want %v", tt.input, *got, *tt.want)
+				}
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
## Summary

Add `tagpr.fixedMajorVersion` configuration option that allows tagpr to target a specific major version when creating releases. This enables maintaining multiple major versions on different branches.

Closes #248

**Use case:**
- v1 branch for v1.x.x releases
- main branch for v2.x.x releases

## Changes

- Add `tagpr.fixedMajorVersion` config option (also via `TAGPR_FIXED_MAJOR_VERSION` env)
- Accept both numeric ("1") and v-prefixed ("v1") formats
- Filter tags in `latestSemverTag()` to only consider matching major versions
- Validation error on invalid values during config reload

## Example Usage

```ini
[tagpr]
    releaseBranch = v1
    fixedMajorVersion = 1
```

Or via environment variable:
```bash
TAGPR_FIXED_MAJOR_VERSION=1
```

## Discussion Points

- Currently only supports major version fixing. Minor version fixing (e.g., for LTS support like v1.0.x) is not implemented as the use case seems rare. Open to discussion if needed.
- If we want to support minor version fixing in the future, we could rename and generalize to `fixedVersion` with pattern support:
  - `fixedVersion = "1"` → fix major version (v1.x.x)
  - `fixedVersion = "1.2"` → fix major and minor version (v1.2.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)