### PR TITLE
Use scoped release yaml path in github releases

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -83,9 +83,10 @@ func (tp *tagpr) tagRelease(ctx context.Context, pr *github.PullRequest, currVer
 	}
 	releases, resp, err := tp.gh.Repositories.GenerateReleaseNotes(
 		ctx, tp.owner, tp.repo, &github.GenerateNotesOptions{
-			TagName:         fullNextTag,
-			PreviousTagName: previousTag,
-			TargetCommitish: &targetCommitish,
+			TagName:               fullNextTag,
+			PreviousTagName:       previousTag,
+			TargetCommitish:       &targetCommitish,
+			ConfigurationFilePath: github.Ptr(tp.cfg.ReleaseYAMLPath()),
 		})
 	if err != nil {
 		showGHError(err, resp)


### PR DESCRIPTION

Use scoped release yaml path in github releases.

#291 introduces release yaml path customization.
But, it does not change releases in github release.

This PR fixes this bug.