### PR TITLE
Add retry to latestPullRequest for commit-to-PR index race condition

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -2,7 +2,9 @@ package tagpr
 
 import (
 	"context"
+	"log"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v83/github"
 )
@@ -13,16 +15,32 @@ func (tp *tagpr) latestPullRequest(ctx context.Context) (*github.PullRequest, er
 	if err != nil {
 		return nil, err
 	}
-	pulls, resp, err := tp.gh.PullRequests.ListPullRequestsWithCommit(
-		ctx, tp.owner, tp.repo, commitish, nil)
-	if err != nil {
-		showGHError(err, resp)
-		return nil, err
+
+	// Retry because GitHub's internal commit-to-PR index may not be updated
+	// immediately after a merge, causing the API to return an empty list.
+	// This is especially common with squash merges but can also happen with
+	// regular merge commits when the workflow triggers within seconds.
+	// See https://github.com/Songmu/tagpr/issues/330
+	const maxRetries = 3
+	const retryInterval = 2 * time.Second
+
+	for i := range maxRetries {
+		pulls, resp, err := tp.gh.PullRequests.ListPullRequestsWithCommit(
+			ctx, tp.owner, tp.repo, commitish, nil)
+		if err != nil {
+			showGHError(err, resp)
+			return nil, err
+		}
+		if len(pulls) > 0 {
+			return pulls[0], nil
+		}
+		if i < maxRetries-1 {
+			log.Printf("ListPullRequestsWithCommit returned empty for %s, retrying in %s (%d/%d)",
+				commitish, retryInterval, i+1, maxRetries)
+			time.Sleep(retryInterval)
+		}
 	}
-	if len(pulls) == 0 {
-		return nil, nil
-	}
-	return pulls[0], nil
+	return nil, nil
 }
 
 func (tp *tagpr) tagRelease(ctx context.Context, pr *github.PullRequest, currVer *semv, latestSemverTag string) error {


### PR DESCRIPTION
Thanks for building tagpr! I use it both at work and in personal projects and it's been great.

## Summary

Add retry logic to `latestPullRequest()` so that tagpr can tolerate the GitHub API's eventual consistency when resolving commits to pull requests.

## Problem

`latestPullRequest()` calls `ListPullRequestsWithCommit` once with no retry. The GitHub API endpoint `GET /repos/{owner}/{repo}/commits/{sha}/pulls` depends on an internal index that associates commits with PRs. This index update is asynchronous — when tagpr queries the API within seconds of a merge, the endpoint may return an empty list.

When this happens, `latestPullRequest` returns `(nil, nil)`, `isTagPR(nil)` returns `false`, and tagpr falls through to create a duplicate release PR instead of tagging the release.

### Real-world example

In [babarot/gh-infra](https://github.com/babarot/gh-infra), the following sequence occurred:

1. [PR #64](https://github.com/babarot/gh-infra/pull/64) (a regular fix) was merged to main at `08:58:58`
2. [PR #62](https://github.com/babarot/gh-infra/pull/62) (a tagpr release PR for v0.7.0) was merged at `08:59:39`
3. The Release workflow triggered for the PR #62 merge commit (`506696d`)
4. tagpr ran and called `ListPullRequestsWithCommit` for `506696d` — the API returned an empty list (index not yet updated, only 13 seconds after merge)
5. tagpr failed to detect its own release PR and created a [duplicate PR #65](https://github.com/babarot/gh-infra/pull/65) instead of tagging v0.7.0
6. The `v0.7.0` tag was never created

This was a regular merge commit (not squash), confirming that the race condition is not limited to squash merges as initially reported in #330.