### PR TITLE
Ignore labels from Dependabot PRs in version determination

### DIFF
--- a/tagpr.go
+++ b/tagpr.go
@@ -30,6 +30,7 @@ const (
 	autoChangelogMessage = "update CHANGELOG.md"
 	autoLabelName        = "tagpr"
 	branchPrefix         = "tagpr-from-"
+	dependabotLogin      = "dependabot[bot]"
 )
 
 type tagpr struct {
@@ -1029,11 +1030,18 @@ func (tp *tagpr) searchIssues(ctx context.Context, query string) ([]*github.Issu
 	return issues.Issues, nil
 }
 
+func isDependabotPR(issue *github.Issue) bool {
+	return issue.GetUser().GetLogin() == dependabotLogin
+}
+
 func (tp *tagpr) generateNextLabels(prIssues []*github.Issue) []string {
 	majorLabels := tp.cfg.MajorLabels()
 	minorLabels := tp.cfg.MinorLabels()
 	var nextMinor, nextMajor bool
 	for _, issue := range prIssues {
+		if isDependabotPR(issue) {
+			continue
+		}
 		for _, l := range issue.Labels {
 			if slices.Contains(minorLabels, l.GetName()) {
 				nextMinor = true

--- a/tagpr_test.go
+++ b/tagpr_test.go
@@ -307,6 +307,106 @@ func TestGenerateNextLabels(t *testing.T) {
 	}
 }
 
+func TestGenerateNextLabels_DependabotIgnored(t *testing.T) {
+	major := "major"
+	minor := "minor"
+	depLogin := dependabotLogin
+	normalLogin := "octocat"
+
+	newIssue := func(login string, labels []*github.Label) *github.Issue {
+		return &github.Issue{
+			User:   &github.User{Login: &login},
+			Labels: labels,
+		}
+	}
+
+	tests := map[string]struct {
+		prIssues []*github.Issue
+		want     []string
+	}{
+		"dependabot major label ignored": {
+			[]*github.Issue{newIssue(depLogin, []*github.Label{newGithubLabel(&major)})},
+			[]string{},
+		},
+		"dependabot minor label ignored": {
+			[]*github.Issue{newIssue(depLogin, []*github.Label{newGithubLabel(&minor)})},
+			[]string{},
+		},
+		"dependabot major and minor labels ignored": {
+			[]*github.Issue{newIssue(depLogin, []*github.Label{newGithubLabel(&major), newGithubLabel(&minor)})},
+			[]string{},
+		},
+		"normal PR major label respected": {
+			[]*github.Issue{newIssue(normalLogin, []*github.Label{newGithubLabel(&major)})},
+			[]string{"tagpr:major"},
+		},
+		"mixed dependabot and normal PR": {
+			[]*github.Issue{
+				newIssue(depLogin, []*github.Label{newGithubLabel(&major)}),
+				newIssue(normalLogin, []*github.Label{newGithubLabel(&minor)}),
+			},
+			[]string{"tagpr:minor"},
+		},
+		"only dependabot PRs results in patch": {
+			[]*github.Issue{
+				newIssue(depLogin, []*github.Label{newGithubLabel(&major)}),
+				newIssue(depLogin, []*github.Label{newGithubLabel(&minor)}),
+			},
+			[]string{},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			tp, err := newTagPR(context.Background(), &commander{
+				gitPath: "git", outStream: os.Stdout, errStream: os.Stderr, dir: "."},
+			)
+			if err != nil {
+				t.Error(err)
+			}
+
+			got := tp.generateNextLabels(tt.prIssues)
+
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got:\n%s,\nwant:\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDependabotPR(t *testing.T) {
+	tests := map[string]struct {
+		login string
+		want  bool
+	}{
+		"dependabot bot": {"dependabot[bot]", true},
+		"normal user":    {"octocat", false},
+		"empty login":    {"", false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			issue := &github.Issue{
+				User: &github.User{Login: &tt.login},
+			}
+			if got := isDependabotPR(issue); got != tt.want {
+				t.Errorf("isDependabotPR() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("nil user", func(t *testing.T) {
+		issue := &github.Issue{}
+		if got := isDependabotPR(issue); got != false {
+			t.Errorf("isDependabotPR() = %v, want false", got)
+		}
+	})
+}
+
 func TestLatestSemverTag(t *testing.T) {
 	vPrefixTrue := true
 	vPrefixFalse := false


### PR DESCRIPTION
## Summary

Ignore labels on Dependabot-created PRs when tagpr determines the next version number.

## Background

- Dependabot automatically adds `major` / `minor` labels to its PRs based on the dependency's SemVer change
- These labels were unintentionally influencing tagpr's version determination, causing the project's own version to bump unexpectedly
- A dependency's SemVer change is a separate concept from the project's own versioning and should not be coupled

## Changes

- Skip PRs authored by `dependabot[bot]` in `generateNextLabels` when collecting labels for next version calculation
- Add `isDependabotPR()` helper function
- Always enabled (no configuration needed) — Dependabot is a GitHub-native feature, so special-casing it is reasonable
- Labels manually added to the tagpr release PR itself are not affected

## Tests

- Dependabot PR with major/minor labels is ignored
- Mixed Dependabot and normal PRs — only normal PR labels are considered
- Unit tests for `isDependabotPR` (including nil user)
