### PR TITLE
Clear PR Base before Edit to avoid duplicate synchronize webhooks

### DIFF
--- a/tagpr.go
+++ b/tagpr.go
@@ -930,6 +930,13 @@ func (tp *tagpr) Run(ctx context.Context) error {
 	}
 	currTagPR.Title = github.Ptr(title)
 	currTagPR.Body = github.Ptr(mergeBody(*currTagPR.Body, body))
+	// Clear Base so go-github does not include the `base` field in the PATCH
+	// payload. When `base` is sent shortly after an UpdateRef (force-push),
+	// GitHub emits a duplicate `pull_request.synchronize` webhook, causing
+	// pull_request-triggered workflows to run twice on the same SHA.
+	// Release PRs never change their base branch, so this is safe.
+	// See: https://github.com/google/go-github/issues/1250
+	currTagPR.Base = nil
 	pr, resp, err := tp.gh.PullRequests.Edit(ctx, tp.owner, tp.repo, *currTagPR.Number, currTagPR)
 	if err != nil {
 		showGHError(err, resp)


### PR DESCRIPTION
Closes #335. Thanks for maintaining tagpr!

As detailed in the issue, GitHub emits a duplicate `pull_request.synchronize` webhook when `PullRequests.Edit` is called shortly after `Git.UpdateRef` with `base` included in the PATCH payload. tagpr hits exactly this condition because `currTagPR.Base` is populated from `PullRequests.List`, and go-github's `Edit` always sends `base` for open PRs ([pulls.go#L378-L380](https://github.com/google/go-github/blob/master/github/pulls.go#L378-L380)).

This PR sets `currTagPR.Base = nil` right before `PullRequests.Edit`, so go-github omits `base` from the PATCH. Release PRs never change their base branch, so this is safe. The same workaround pattern is used in google/go-github#1250.

### Alternatives considered
- **Reverse order (Edit → UpdateRef)**: leaves a window where the PR body describes a commit not yet on the branch, and complicates error handling.
- **Sleep between the two calls**: works but adds wall-clock time to every release-PR update and depends on an undocumented async operation.