### PR TITLE
fix: respect version labels in monorepo using --first-parent

### DIFF
--- a/tagpr.go
+++ b/tagpr.go
@@ -405,7 +405,7 @@ func (tp *tagpr) Run(ctx context.Context) error {
 		tp.setOutput("pull_request", string(b))
 		return nil
 	}
-	mergeLogArgs := []string{"log", "--merges", "--pretty=format:%P",
+	mergeLogArgs := []string{"log", "--merges", "--first-parent", "--pretty=format:%P",
 		fmt.Sprintf("%s..%s/%s", fromCommitish, tp.remoteName, releaseBranch)}
 	if tp.normalizedTagPrefix != "" {
 		mergeLogArgs = append(mergeLogArgs, "--", strings.TrimSuffix(tp.normalizedTagPrefix, "/"))

--- a/tagpr_test.go
+++ b/tagpr_test.go
@@ -472,9 +472,9 @@ func TestBuildGitLogArgsWithPathFilter(t *testing.T) {
 		},
 		{
 			name:                "merge log with prefix",
-			baseArgs:            []string{"log", "--merges", "--pretty=format:%P", "v1.0.0..origin/main"},
+			baseArgs:            []string{"log", "--merges", "--first-parent", "--pretty=format:%P", "v1.0.0..origin/main"},
 			normalizedTagPrefix: "packages/core/",
-			wantArgs:            []string{"log", "--merges", "--pretty=format:%P", "v1.0.0..origin/main", "--", "packages/core"},
+			wantArgs:            []string{"log", "--merges", "--first-parent", "--pretty=format:%P", "v1.0.0..origin/main", "--", "packages/core"},
 		},
 		{
 			name:                "cherry-pick log with prefix",


### PR DESCRIPTION
### Description
In a monorepo setup using `tagPrefix` (path filtering), merging a Pull Request with `major` or `minor` labels does not result in the expected version bump; instead, it always defaults to a `patch` release.

When executing a log command with a path filter (e.g., `git log --merges ... -- packages/core`), Git's "History Simplification" causes the result of merge commits to not be reflected in the output. Since `tagpr` relies on the SHA obtained from this log to determine the PR labels, the corresponding PR is skipped.

Adding the `--first-parent` option to the `git log` command in `tagpr.go` ensures that the history on the release branch is prioritized, preventing merge commits from being simplified away by TREESAME, and allows all PR merges that affect the path to be correctly retrieved.

Closes https://github.com/Songmu/tagpr/issues/339