### PR TITLE
Fix previous tag detection after switching from semver to calver

### DIFF
--- a/calver_test.go
+++ b/calver_test.go
@@ -427,6 +427,154 @@ func TestCalverWithTagPrefix(t *testing.T) {
 	}
 }
 
+// TestCalverWithMixedSemverTags verifies that latestSemverTag() correctly
+// returns the latest calver tag when both semver and calver tags exist,
+// ignoring semver tags that don't match the calver format.
+func TestCalverWithMixedSemverTags(t *testing.T) {
+	tests := []struct {
+		name    string
+		tags    []string
+		vPrefix bool
+		format  string
+		wantTag string
+	}{
+		// defaultCalendarVersioningFormat (YYYY.MM0D.MICRO) - no leading zeros
+		{
+			name:    "default format: ignores semver tags and returns latest calver tag",
+			tags:    []string{"v7.8.0", "v2026.403.0"},
+			vPrefix: true,
+			format:  defaultCalendarVersioningFormat,
+			wantTag: "v2026.403.0",
+		},
+		{
+			name:    "default format: returns latest calver among multiple calver and semver tags",
+			tags:    []string{"v1.0.0", "v2.3.4", "v2026.403.1", "v2026.403.3"},
+			vPrefix: true,
+			format:  defaultCalendarVersioningFormat,
+			wantTag: "v2026.403.3",
+		},
+		{
+			name:    "default format: returns empty when no calver tags exist",
+			tags:    []string{"v1.0.0", "v7.8.0"},
+			vPrefix: true,
+			format:  defaultCalendarVersioningFormat,
+			wantTag: "",
+		},
+		// zero-padded format (YYYY.0M0D.MICRO) - produces leading zeros that
+		// gitsemvers rejects as invalid semver
+		{
+			name:    "zero-padded format: ignores semver tags and returns latest calver tag",
+			tags:    []string{"v7.8.0", "v2026.0403.0"},
+			vPrefix: true,
+			format:  "YYYY.0M0D.MICRO",
+			wantTag: "v2026.0403.0",
+		},
+		{
+			name:    "zero-padded format: returns latest calver among multiple calver and semver tags",
+			tags:    []string{"v1.0.0", "v2.3.4", "v2026.0403.1", "v2026.0403.3"},
+			vPrefix: true,
+			format:  "YYYY.0M0D.MICRO",
+			wantTag: "v2026.0403.3",
+		},
+		{
+			name:    "zero-padded format: returns empty when no calver tags exist",
+			tags:    []string{"v1.0.0", "v7.8.0"},
+			vPrefix: true,
+			format:  "YYYY.0M0D.MICRO",
+			wantTag: "",
+		},
+		// format filters: only tags matching the configured format are recognized
+		{
+			name:    "zero-padded format ignores non-zero-padded tags",
+			tags:    []string{"v7.8.0", "v2026.403.0", "v2026.0403.0"},
+			vPrefix: true,
+			format:  "YYYY.0M0D.MICRO",
+			wantTag: "v2026.0403.0",
+		},
+		{
+			name:    "default format ignores zero-padded tags",
+			tags:    []string{"v7.8.0", "v2026.0403.0", "v2026.403.0"},
+			vPrefix: true,
+			format:  defaultCalendarVersioningFormat,
+			wantTag: "v2026.403.0",
+		},
+		// calver disabled
+		{
+			name:    "falls back to semver when calver format is empty",
+			tags:    []string{"v1.0.0", "v7.8.0", "v2026.0403.0"},
+			vPrefix: true,
+			format:  "",
+			wantTag: "v7.8.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "tagpr-calver-mixed-test-*")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+			runGit := func(args ...string) {
+				cmd := exec.Command("git", args...)
+				cmd.Dir = tmpDir
+				cmd.Env = append(os.Environ(),
+					"GIT_AUTHOR_NAME=Test",
+					"GIT_AUTHOR_EMAIL=test@example.com",
+					"GIT_COMMITTER_NAME=Test",
+					"GIT_COMMITTER_EMAIL=test@example.com",
+				)
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("git %v failed: %v\n%s", args, err, out)
+				}
+			}
+
+			runGit("init")
+			runGit("config", "user.email", "test@example.com")
+			runGit("config", "user.name", "Test")
+
+			testFile := filepath.Join(tmpDir, "test.txt")
+			if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
+			runGit("add", "test.txt")
+			runGit("commit", "-m", "initial commit")
+
+			for _, tag := range tt.tags {
+				runGit("tag", tag)
+			}
+
+			// gitsemvers (used in semver fallback path) relies on the current
+			// working directory, so chdir to the temp repo.
+			origDir, _ := os.Getwd()
+			os.Chdir(tmpDir)
+			t.Cleanup(func() { os.Chdir(origDir) })
+
+			c := &commander{
+				gitPath:   "git",
+				dir:       tmpDir,
+				outStream: os.Stdout,
+				errStream: os.Stderr,
+			}
+			tp := &tagpr{
+				c:       c,
+				gitPath: "git",
+				cfg: &config{
+					vPrefix:            &tt.vPrefix,
+					calendarVersioning: &tt.format,
+				},
+				normalizedTagPrefix: "",
+			}
+
+			got := tp.latestSemverTag()
+			if got != tt.wantTag {
+				t.Errorf("latestSemverTag() = %q, want %q", got, tt.wantTag)
+			}
+		})
+	}
+}
+
 func TestZeroPaddedCalver(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "tagpr-calver-test-*")
 	if err != nil {

--- a/calver_test.go
+++ b/calver_test.go
@@ -500,11 +500,18 @@ func TestCalverWithMixedSemverTags(t *testing.T) {
 		},
 		// calver disabled
 		{
-			name:    "falls back to semver when calver format is empty",
+			name:    "falls back to semver with zero-padded calver tag ignored",
 			tags:    []string{"v1.0.0", "v7.8.0", "v2026.0403.0"},
 			vPrefix: true,
 			format:  "",
 			wantTag: "v7.8.0",
+		},
+		{
+			name:    "falls back to semver with non-zero-padded calver tag also matched",
+			tags:    []string{"v1.0.0", "v7.8.0", "v2026.403.0"},
+			vPrefix: true,
+			format:  "",
+			wantTag: "v2026.403.0",
 		},
 	}
 

--- a/gh2changelog/options.go
+++ b/gh2changelog/options.go
@@ -60,3 +60,11 @@ func FilteredMajorVersion(v uint64) Option {
 		gch.filteredMajorVersion = &v
 	}
 }
+
+// VersionTags sets the version tag list directly, bypassing gitsemvers auto-detection.
+// This is useful when the versioning scheme (e.g., CalVer) is not compatible with semver parsing.
+func VersionTags(vers []string) Option {
+	return func(gch *GH2Changelog) {
+		gch.semvers = vers
+	}
+}

--- a/tagpr.go
+++ b/tagpr.go
@@ -776,6 +776,9 @@ func (tp *tagpr) Run(ctx context.Context) error {
 	if fixedMajor, err := tp.cfg.FixedMajorVersion(); err == nil && fixedMajor != nil {
 		opts = append(opts, gh2changelog.FilteredMajorVersion(*fixedMajor))
 	}
+	if tp.cfg.CalendarVersioning() && latestSemverTag != "" {
+		opts = append(opts, gh2changelog.VersionTags([]string{latestSemverTag}))
+	}
 	gch, err := gh2changelog.New(ctx, opts...)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

After migrating from semver to calver, I noticed the "Full Changelog" link in the release PR body was pointing to the wrong previous version (e.g., `v7.8.0...v26.04.4` instead of `v26.04.3...v26.04.4`).

The root cause is that `gh2changelog` independently uses `gitsemvers` to detect version tags, but `gitsemvers` cannot parse calver tags with zero-padded components (e.g., `04` in `v26.04.3` violates the semver spec). This causes it to fall back to the last valid semver tag.

This PR adds a `VersionTags` option to `gh2changelog` so that `tagpr` can pass the correctly detected calver tag directly, bypassing the incompatible `gitsemvers` auto-detection.

- Added `VersionTags` option to `gh2changelog/options.go`
- Pass calver tag via `VersionTags` when calendar versioning is enabled in `tagpr.go`
- Added tests for calver tag detection with mixed semver/calver tags

## Test plan

- [x] `TestCalverWithMixedSemverTags` covers default format, zero-padded format, format filtering, and semver fallback
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)