### PR TITLE
feat: support Cargo.toml as a version file for Rust projects

### DIFF
--- a/testdata/rust/Cargo.toml
+++ b/testdata/rust/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tagpr-rust-fixture"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0.100"

--- a/versionfile.go
+++ b/versionfile.go
@@ -130,6 +130,8 @@ func versionFile(files []string) (string, string) {
 			return f, "javascript"
 		case "pom.xml":
 			return f, "java"
+		case "cargo.toml":
+			return f, "rust"
 		case "meta.json":
 			if meta == "" {
 				meta = f

--- a/versionfile_test.go
+++ b/versionfile_test.go
@@ -73,3 +73,14 @@ func TestDetectVersionFile_perl(t *testing.T) {
 		t.Errorf("error: %s", f)
 	}
 }
+
+func TestDetectVersionFile_rust(t *testing.T) {
+	v, _ := newSemver("v1.0.0")
+	f, err := detectVersionFile("testdata/rust", v)
+	if err != nil {
+		t.Errorf("error should be nil, but: %s", err)
+	}
+	if f != "Cargo.toml" {
+		t.Errorf("error: %s", f)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `cargo.toml` (matched case-insensitively as `Cargo.toml`) to the language detection switch in `versionFile()` so Rust projects are recognized explicitly instead of falling through to the generic first-file branch.
- Add `testdata/rust/Cargo.toml` fixture (with a `[package]` version and an unrelated `[dependencies]` entry) and `TestDetectVersionFile_rust` to lock in the behavior.

The existing version regex already matches `version = "x.y.z"` lines and `bumpVersionFile` only rewrites the first occurrence, so dependency versions in `[dependencies]` are not touched. `Cargo.lock` is already excluded by the `*.lock` skip rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)