### PR TITLE
Add blank line after changelog heading to be markdownlint-safe

### DIFF
--- a/gh2changelog/changelog.go
+++ b/gh2changelog/changelog.go
@@ -36,7 +36,8 @@ func convertKeepAChangelogFormat(md string, d time.Time) string {
 		// empty
 		return heading + "\n"
 	}
-	md = strings.Replace(md, origHeading, heading, 1)
+	// Insert a blank line after the heading to be markdownlint-safe (MD022).
+	md = strings.Replace(md, origHeading, heading+"\n", 1)
 	md = strings.ReplaceAll(md, "\n* ", "\n- ")
 	md = newContribReg.ReplaceAllString(md, "")
 

--- a/gh2changelog/changelog_test.go
+++ b/gh2changelog/changelog_test.go
@@ -19,6 +19,7 @@ func TestConvertKeepAChangelogFormat(t *testing.T) {
 `
 
 	expect := `## [v0.0.1](https://github.com/Songmu/gh2changelog/commits/v0.0.1) - 2022-08-16
+
 - add github.go for github client by @Songmu in https://github.com/Songmu/gh2changelog/pull/1
 - tagging semver to merged gh2changelog by @Songmu in https://github.com/Songmu/gh2changelog/pull/19
 `

--- a/gh2changelog/gh2changelog_test.go
+++ b/gh2changelog/gh2changelog_test.go
@@ -26,6 +26,7 @@ func TestGH2Changelog(t *testing.T) {
 		t.Error(err)
 	}
 	expect := `## [v1.0.1](https://github.com/Songmu/gh2changelog/commits/v1.0.1) - 2022-09-03
+
 - add github.go for github client by @Songmu in https://github.com/Songmu/gh2changelog/pull/1
 - tagging semver to merged gh2changelog by @Songmu in https://github.com/Songmu/gh2changelog/pull/19
 `
@@ -38,6 +39,7 @@ func TestGH2Changelog(t *testing.T) {
 		t.Error(err)
 	}
 	expect = `## [v1.0.1](https://github.com/Songmu/gh2changelog/commits/v1.0.1) - 2022-08-17
+
 - add github.go for github client by @Songmu in https://github.com/Songmu/gh2changelog/pull/1
 - tagging semver to merged gh2changelog by @Songmu in https://github.com/Songmu/gh2changelog/pull/19
 `
@@ -50,6 +52,7 @@ func TestGH2Changelog(t *testing.T) {
 		t.Error(err)
 	}
 	expect = `## [Unreleased](https://github.com/Songmu/gh2changelog/commits/HEAD)
+
 - add github.go for github client by @Songmu in https://github.com/Songmu/gh2changelog/pull/1
 - tagging semver to merged gh2changelog by @Songmu in https://github.com/Songmu/gh2changelog/pull/19
 `
@@ -62,6 +65,7 @@ func TestGH2Changelog(t *testing.T) {
 		t.Error(err)
 	}
 	expect = `## [v1.0.1](https://github.com/Songmu/gh2changelog/commits/v1.0.1) - 2022-08-17
+
 - add github.go for github client by @Songmu in https://github.com/Songmu/gh2changelog/pull/1
 - tagging semver to merged gh2changelog by @Songmu in https://github.com/Songmu/gh2changelog/pull/19
 `
@@ -75,6 +79,7 @@ func TestGH2Changelog(t *testing.T) {
 	}
 	out = outs[0]
 	expect = `## [v1.0.1](https://github.com/Songmu/gh2changelog/commits/v1.0.1) - 2022-08-17
+
 - add github.go for github client by @Songmu in https://github.com/Songmu/gh2changelog/pull/1
 - tagging semver to merged gh2changelog by @Songmu in https://github.com/Songmu/gh2changelog/pull/19
 `
@@ -89,6 +94,7 @@ func TestGH2Changelog(t *testing.T) {
 	expect = `# Changelog
 
 ## [v1.0.1](https://github.com/Songmu/gh2changelog/commits/v1.0.1) - 2022-08-17
+
 - add github.go for github client by @Songmu in https://github.com/Songmu/gh2changelog/pull/1
 - tagging semver to merged gh2changelog by @Songmu in https://github.com/Songmu/gh2changelog/pull/19
 `
@@ -103,10 +109,12 @@ func TestGH2Changelog(t *testing.T) {
 	expect = `# Changelog
 
 ## [Unreleased](https://github.com/Songmu/gh2changelog/commits/HEAD)
+
 - add github.go for github client by @Songmu in https://github.com/Songmu/gh2changelog/pull/1
 - tagging semver to merged gh2changelog by @Songmu in https://github.com/Songmu/gh2changelog/pull/19
 
 ## [v1.0.1](https://github.com/Songmu/gh2changelog/commits/v1.0.1) - 2022-08-17
+
 - add github.go for github client by @Songmu in https://github.com/Songmu/gh2changelog/pull/1
 - tagging semver to merged gh2changelog by @Songmu in https://github.com/Songmu/gh2changelog/pull/19
 `


### PR DESCRIPTION
The generated changelog entry put list items directly after the `## [version]` heading with no blank line. This violates markdownlint [MD022](https://github.com/DavidAnson/markdownlint/blob/main/doc/md022.md) and causes formatter drift. This adds a blank line after the heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)