### PR TITLE
fix: preserve CalVer zero-padding when tagging from a version file

### DIFF
--- a/calver_test.go
+++ b/calver_test.go
@@ -250,6 +250,31 @@ func TestGuessNextWithCalver(t *testing.T) {
 	}
 }
 
+// TestRetrieveVersionFromFilePreservesCalverPadding reproduces issue #345
+// Problem 1: when tagRelease reads the next version from a version file, the
+// resulting semv must inherit the calver scheme from the reference semv,
+// otherwise Naked()/Tag() normalize via Masterminds/semver and strip the
+// month's leading zero (v2026.0415.0 -> v2026.415.0).
+func TestRetrieveVersionFromFilePreservesCalverPadding(t *testing.T) {
+	dir := t.TempDir()
+	vf := filepath.Join(dir, "RELEASE_VERSION")
+	if err := os.WriteFile(vf, []byte("v2026.0415.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := &semv{vPrefix: true, asCalendarVersion: true, calverFormat: "YYYY.0M0D.MICRO"}
+	ver, err := retrieveVersionFromFile(vf, ref)
+	if err != nil {
+		t.Fatalf("retrieveVersionFromFile failed: %v", err)
+	}
+	if got := ver.Tag(); got != "v2026.0415.0" {
+		t.Errorf("Tag() = %q, want %q (leading zero must be preserved)", got, "v2026.0415.0")
+	}
+	if got := ver.Naked(); got != "2026.0415.0" {
+		t.Errorf("Naked() = %q, want %q (leading zero must be preserved)", got, "2026.0415.0")
+	}
+}
+
 func TestNakedPreservesZeroPadding(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/tag.go
+++ b/tag.go
@@ -71,7 +71,7 @@ func (tp *tagpr) tagRelease(ctx context.Context, pr *github.PullRequest, currVer
 
 	var nextTag string
 	if vfile != "" {
-		nextVer, err := retrieveVersionFromFile(vfile, currVer.vPrefix)
+		nextVer, err := retrieveVersionFromFile(vfile, currVer)
 		if err != nil {
 			return err
 		}

--- a/tagpr.go
+++ b/tagpr.go
@@ -756,7 +756,7 @@ func (tp *tagpr) Run(ctx context.Context) error {
 				}
 			}
 		} else {
-			nVer, _ := retrieveVersionFromFile(vfiles[0], nextVer.vPrefix)
+			nVer, _ := retrieveVersionFromFile(vfiles[0], nextVer)
 			if nVer != nil && nVer.Naked() != nextVer.Naked() {
 				nextVer = nVer
 			}

--- a/versionfile.go
+++ b/versionfile.go
@@ -197,7 +197,11 @@ func bumpVersionFile(fpath string, from, to *semv) error {
 	return os.WriteFile(fpath, updated, 0666)
 }
 
-func retrieveVersionFromFile(fpath string, vPrefix bool) (*semv, error) {
+// retrieveVersionFromFile reads a version string from fpath and constructs a
+// semv that inherits the versioning scheme (vPrefix/calver) from ref. The
+// scheme must be inherited: a calver value parsed without asCalendarVersion set
+// gets normalized via Masterminds/semver, stripping zero-padding (see #345).
+func retrieveVersionFromFile(fpath string, ref *semv) (*semv, error) {
 	bs, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, err
@@ -212,8 +216,14 @@ func retrieveVersionFromFile(fpath string, vPrefix bool) (*semv, error) {
 		}
 		ver = string(m[1])
 	}
-	if vPrefix {
+	if ref.vPrefix {
 		ver = "v" + ver
 	}
-	return newSemver(ver)
+	sv, err := newSemver(ver)
+	if err != nil {
+		return nil, err
+	}
+	sv.asCalendarVersion = ref.asCalendarVersion
+	sv.calverFormat = ref.calverFormat
+	return sv, nil
 }

--- a/versionfile_test.go
+++ b/versionfile_test.go
@@ -28,7 +28,7 @@ func TestFileOrder(t *testing.T) {
 	}
 }
 func TestRetrieveVersionFile(t *testing.T) {
-	ver, err := retrieveVersionFromFile("version.go", false)
+	ver, err := retrieveVersionFromFile("version.go", &semv{vPrefix: false})
 	if err != nil {
 		t.Error(err)
 	}
@@ -36,17 +36,17 @@ func TestRetrieveVersionFile(t *testing.T) {
 		t.Errorf("detected: %s, expected: %s", ver.Naked(), version)
 	}
 
-	ver, _ = retrieveVersionFromFile("testdata/vfile1", true)
+	ver, _ = retrieveVersionFromFile("testdata/vfile1", &semv{vPrefix: true})
 	if e, g := "v1.2.3", ver.Tag(); e != g {
 		t.Errorf("got: %s, expected: %s", g, e)
 	}
 
-	ver, _ = retrieveVersionFromFile("testdata/vfile2", false)
+	ver, _ = retrieveVersionFromFile("testdata/vfile2", &semv{vPrefix: false})
 	if e, g := "1.3.5", ver.Tag(); e != g {
 		t.Errorf("got: %s, expected: %s", g, e)
 	}
 
-	ver, _ = retrieveVersionFromFile("testdata/vfile3", false)
+	ver, _ = retrieveVersionFromFile("testdata/vfile3", &semv{vPrefix: false})
 	if e, g := "12.3.4", ver.Tag(); e != g {
 		t.Errorf("got: %s, expected: %s", g, e)
 	}


### PR DESCRIPTION
Fixes #345 (Problem 1). A version file with a zero-padded CalVer (`YYYY.0M0D.MICRO`) produced an unpadded git tag.

## The bug

| | version file | created tag |
|---|---|---|
| before | `v2026.0415.0` | `v2026.415.0` ❌ (leading zero dropped) |
| after  | `v2026.0415.0` | `v2026.0415.0` ✅ |

## Root cause

`tagRelease` reads the next version from the version file via `retrieveVersionFromFile`
(`tag.go:74`). That helper built the `semv` with `newSemver` only, so the result had
`asCalendarVersion == false`. `Naked()`/`Tag()` then took the SemVer path
(`sv.sv.String()`), which normalizes through Masterminds/semver and strips the
leading zero.

The configured `currVer` passed into `tagRelease` already knows it is CalVer
(`asCalendarVersion`/`calverFormat` are set in `Run`), but that identity was never
propagated to the file-derived version. This matches the cause suspected in #345.

## The fix

Make the construction site carry the scheme, instead of patching the one call path:

```go
-func retrieveVersionFromFile(fpath string, vPrefix bool) (*semv, error) {
+func retrieveVersionFromFile(fpath string, ref *semv) (*semv, error) {
 ...
-	return newSemver(ver)
+	sv, err := newSemver(ver)
+	if err != nil {
+		return nil, err
+	}
+	sv.asCalendarVersion = ref.asCalendarVersion
+	sv.calverFormat = ref.calverFormat
+	return sv, nil
 }
```

Both callers already hold a correctly-configured reference `semv`, so they just pass it:
- `tag.go:74` → `retrieveVersionFromFile(vfile, currVer)`
- `tagpr.go:759` → `retrieveVersionFromFile(vfiles[0], nextVer)`

Problem 2 in #345 (`bumpVersionFile` not matching the file) is a downstream effect of
the unpadded tag and disappears once tags stay padded.

## Why this shape

- Fixes the helper itself, so any caller that reads a version from a file is correct by
  construction — not a special-case in `tagRelease`.
- No new config/option, no user-facing behavior change beyond the bug fix.

## Safety / no behavior change elsewhere

- **SemVer repos**: `currVer`/`nextVer` have `asCalendarVersion == false`, so the
  inherited values are zero and `Naked()` keeps the existing SemVer path. Confirmed by
  the unchanged `TestRetrieveVersionFile`.
- **`tagpr.go:759`** is the non-CalVer branch already, so passing `nextVer` is equivalent
  to the old `nextVer.vPrefix`.
- Skipping tags that don't match the configured CalVer format is **existing, intended
  behavior** (covered by `TestCalverWithMixedSemverTags`) and is **not** changed here.

## Test plan

- [x] `TestRetrieveVersionFromFilePreservesCalverPadding` — new, reproduces #345 Problem 1
- [x] `TestRetrieveVersionFile` — updated for the new signature
- [x] `go test ./...` passes (the pre-existing, network-dependent `TestLatestSemverTag`
      failure is unrelated to this change)
- [x] `gofmt` / `go vet` clean

<details>
<summary>Migration note for repositories already bitten by this bug</summary>

The bug only drops the leading zero for **single-digit months** (Jan–Sep); Oct–Dec tags
were already correct. A malformed tag such as `v2026.415.0` does **not** parse under the
corrected zero-padded format, so after this fix `latestCalverTag()` silently skips it
(verified) — it becomes invisible to tagpr. The next release then either picks an older
parseable tag as the base, or, if none parse, starts fresh from today's date (date-based
monotonicity is preserved, but the changelog base may be off once).

Recommended recovery — re-tag the malformed tag with zero-padding on the same commit:

```bash
COMMIT=$(git rev-list -n1 v2026.415.0)
git tag v2026.0415.0 "$COMMIT"
git push origin v2026.0415.0
git tag -d v2026.415.0
git push origin :refs/tags/v2026.415.0
# Re-point any GitHub Release to the new tag, and make sure the version file matches.
```

Caveat: deleting/moving an already-published tag is destructive. If the repo is a Go
module (or the tag is consumed elsewhere), the proxy treats tags as immutable — in that
case keep the old tag and let the next release self-heal as the date advances, accepting
one imperfect changelog base.

</details>