### PR TITLE
feat: add tagpr.releaseNoteCommand to fully generate release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ Command to change files just before release and versioning.
 ### tagpr.postVersionCommand (Optional)
 Command to change files just after versioning.
 
+### tagpr.releaseNoteCommand (Optional)
+Command to generate additional release note content.
+It receives the previous tag and the new tag as positional arguments (`$1` and `$2`; `$1` is empty for the first release), and its standard output is appended to the bottom of the GitHub-generated release notes.
+It runs twice: once while drafting the release pull request, where the output is also appended to the new entry in `tagpr.changelogFile`, and once just before the GitHub Release is created.
+tagpr fails if the command exits with a non-zero status.
+
 ### tagpr.template (Optional)
 Pull request template file in go template format
 
@@ -223,6 +229,11 @@ When running `tagpr.command` or `tagpr.postVersionCommand`, tagpr exports the fo
 
 - `TAGPR_CURRENT_VERSION`: the current version tag (e.g., `v1.2.3`)
 - `TAGPR_NEXT_VERSION`: the next version tag (e.g., `v1.3.0`)
+
+When running `tagpr.releaseNoteCommand`, tagpr exports the following environment variables in addition to passing the same values as positional arguments:
+
+- `TAGPR_BASE_REF`: the previous version tag (empty for the first release)
+- `TAGPR_HEAD_REF`: the new version tag being released
 
 ## Outputs for GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ Command to change files just before release and versioning.
 Command to change files just after versioning.
 
 ### tagpr.releaseNoteCommand (Optional)
-Command to generate additional release note content.
-It receives the previous tag and the new tag as positional arguments (`$1` and `$2`; `$1` is empty for the first release), and its standard output is appended to the bottom of the GitHub-generated release notes.
-It runs twice: once while drafting the release pull request, where the output is also appended to the new entry in `tagpr.changelogFile`, and once just before the GitHub Release is created.
+Command to fully generate the release note content, bypassing GitHub's release notes generation API.
+It receives the previous tag and the new tag as positional arguments (`$1` and `$2`; `$1` is empty for the first release), and its standard output becomes the release note as-is (GitHub's release notes API is not called).
+It runs twice: once while drafting the release pull request, where the output becomes the new entry in `tagpr.changelogFile`, and once just before the GitHub Release is created, where it becomes the release body.
 tagpr fails if the command exits with a non-zero status.
 
 ### tagpr.template (Optional)

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Command to change files just after versioning.
 ### tagpr.releaseNoteCommand (Optional)
 Command to fully generate the release note content, bypassing GitHub's release notes generation API.
 It receives the previous tag and the new tag as positional arguments (`$1` and `$2`; `$1` is empty for the first release), and its standard output becomes the release note as-is (GitHub's release notes API is not called).
+The commit-ish tagpr would have passed as `TargetCommitish` to the bypassed API call is exposed via the `TAGPR_TARGET_COMMITISH` environment variable.
 It runs twice: once while drafting the release pull request, where the output becomes the new entry in `tagpr.changelogFile`, and once just before the GitHub Release is created, where it becomes the release body.
 tagpr fails if the command exits with a non-zero status.
 
@@ -230,10 +231,11 @@ When running `tagpr.command` or `tagpr.postVersionCommand`, tagpr exports the fo
 - `TAGPR_CURRENT_VERSION`: the current version tag (e.g., `v1.2.3`)
 - `TAGPR_NEXT_VERSION`: the next version tag (e.g., `v1.3.0`)
 
-When running `tagpr.releaseNoteCommand`, tagpr exports the following environment variables in addition to passing the same values as positional arguments:
+When running `tagpr.releaseNoteCommand`, tagpr exports the following environment variables (`TAGPR_BASE_REF` and `TAGPR_HEAD_REF` are also passed as positional arguments `$1` and `$2`):
 
 - `TAGPR_BASE_REF`: the previous version tag (empty for the first release)
 - `TAGPR_HEAD_REF`: the new version tag being released
+- `TAGPR_TARGET_COMMITISH`: the commit-ish tagpr would have passed as `TargetCommitish` to GitHub's release notes generation API
 
 ## Outputs for GitHub Actions
 

--- a/config.go
+++ b/config.go
@@ -42,6 +42,16 @@ const (
 #   tagpr.postVersionCommand (Optional)
 #       Command to change files just after versioning.
 #
+#   tagpr.releaseNoteCommand (Optional)
+#       Command to generate additional release note content. It receives the
+#       previous tag and the new tag as positional arguments ($1 and $2; $1 is
+#       empty for the first release), and its standard output is appended to the
+#       bottom of the GitHub-generated release notes. It runs twice: once while
+#       drafting the release pull request, where the output is also appended to
+#       the new entry in tagpr.changelogFile, and once just before the GitHub
+#       Release is created.
+#       tagpr fails if the command exits with a non-zero status.
+#
 #   tagpr.template (Optional)
 #       Pull request template file in go template format
 #
@@ -106,6 +116,7 @@ const (
 	envChangelog                    = "TAGPR_CHANGELOG"
 	envCommand                      = "TAGPR_COMMAND"
 	envPostVersionCommand           = "TAGPR_POST_VERSION_COMMAND"
+	envReleaseNoteCommand           = "TAGPR_RELEASE_NOTE_COMMAND"
 	envTemplate                     = "TAGPR_TEMPLATE"
 	envTemplateText                 = "TAGPR_TEMPLATE_TEXT"
 	envRelease                      = "TAGPR_RELEASE"
@@ -123,6 +134,7 @@ const (
 	configChangelog                 = "tagpr.changelog"
 	configCommand                   = "tagpr.command"
 	configPostVersionCommand        = "tagpr.postVersionCommand"
+	configReleaseNoteCommand        = "tagpr.releaseNoteCommand"
 	configTemplate                  = "tagpr.template"
 	configTemplateText              = "tagpr.templateText"
 	configRelease                   = "tagpr.release"
@@ -141,6 +153,7 @@ type config struct {
 	versionFile        *string
 	command            *string
 	postVersionCommand *string
+	releaseNoteCommand *string
 	template           *string
 	templateText       *string
 	release            *string
@@ -188,6 +201,8 @@ func (cfg *config) Reload() error {
 	cfg.reloadField(&cfg.command, configCommand, envCommand, "")
 
 	cfg.reloadField(&cfg.postVersionCommand, configPostVersionCommand, envPostVersionCommand, "")
+
+	cfg.reloadField(&cfg.releaseNoteCommand, configReleaseNoteCommand, envReleaseNoteCommand, "")
 
 	cfg.reloadField(&cfg.template, configTemplate, envTemplate, "")
 
@@ -334,6 +349,10 @@ func (cfg *config) Command() string {
 
 func (cfg *config) PostVersionCommand() string {
 	return stringify(cfg.postVersionCommand)
+}
+
+func (cfg *config) ReleaseNoteCommand() string {
+	return stringify(cfg.releaseNoteCommand)
 }
 
 func (cfg *config) Template() string {

--- a/config.go
+++ b/config.go
@@ -46,10 +46,13 @@ const (
 #       Command to fully generate the release note content, bypassing GitHub's
 #       release notes generation API. It receives the previous tag and the new
 #       tag as positional arguments ($1 and $2; $1 is empty for the first
-#       release), and its standard output becomes the release note as-is. It
-#       runs twice: once while drafting the release pull request, where the
-#       output becomes the new entry in tagpr.changelogFile, and once just
-#       before the GitHub Release is created, where it becomes the release body.
+#       release), and its standard output becomes the release note as-is. The
+#       commit-ish tagpr would have used as TargetCommitish for the bypassed
+#       API call is exposed via the TAGPR_TARGET_COMMITISH environment
+#       variable. It runs twice: once while drafting the release pull
+#       request, where the output becomes the new entry in
+#       tagpr.changelogFile, and once just before the GitHub Release is
+#       created, where it becomes the release body.
 #       tagpr fails if the command exits with a non-zero status.
 #
 #   tagpr.template (Optional)

--- a/config.go
+++ b/config.go
@@ -43,13 +43,13 @@ const (
 #       Command to change files just after versioning.
 #
 #   tagpr.releaseNoteCommand (Optional)
-#       Command to generate additional release note content. It receives the
-#       previous tag and the new tag as positional arguments ($1 and $2; $1 is
-#       empty for the first release), and its standard output is appended to the
-#       bottom of the GitHub-generated release notes. It runs twice: once while
-#       drafting the release pull request, where the output is also appended to
-#       the new entry in tagpr.changelogFile, and once just before the GitHub
-#       Release is created.
+#       Command to fully generate the release note content, bypassing GitHub's
+#       release notes generation API. It receives the previous tag and the new
+#       tag as positional arguments ($1 and $2; $1 is empty for the first
+#       release), and its standard output becomes the release note as-is. It
+#       runs twice: once while drafting the release pull request, where the
+#       output becomes the new entry in tagpr.changelogFile, and once just
+#       before the GitHub Release is created, where it becomes the release body.
 #       tagpr fails if the command exits with a non-zero status.
 #
 #   tagpr.template (Optional)

--- a/config_test.go
+++ b/config_test.go
@@ -275,6 +275,51 @@ func TestFixedMajorVersion(t *testing.T) {
 	}
 }
 
+func TestConfigReleaseNoteCommand(t *testing.T) {
+	tmpdir := t.TempDir()
+	confPath := filepath.Join(tmpdir, defaultConfigFile)
+	cfg := &config{
+		conf:      confPath,
+		gitconfig: &gitconfig.Config{GitPath: "git", File: confPath},
+	}
+
+	if err := cfg.Reload(); err != nil {
+		t.Error(err)
+	}
+	if e, g := "", cfg.ReleaseNoteCommand(); e != g {
+		t.Errorf("got: %q, expect: %q", g, e)
+	}
+
+	if err := cfg.set(configReleaseNoteCommand, "./scripts/release-note.sh"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.Reload(); err != nil {
+		t.Error(err)
+	}
+	if e, g := "./scripts/release-note.sh", cfg.ReleaseNoteCommand(); e != g {
+		t.Errorf("got: %q, expect: %q", g, e)
+	}
+}
+
+func TestConfigReleaseNoteCommandFromEnv(t *testing.T) {
+	tmpdir := t.TempDir()
+	confPath := filepath.Join(tmpdir, defaultConfigFile)
+
+	t.Setenv("TAGPR_RELEASE_NOTE_COMMAND", "./scripts/release-note.sh")
+
+	cfg := &config{
+		conf:      confPath,
+		gitconfig: &gitconfig.Config{GitPath: "git", File: confPath},
+	}
+
+	if err := cfg.Reload(); err != nil {
+		t.Error(err)
+	}
+	if e, g := "./scripts/release-note.sh", cfg.ReleaseNoteCommand(); e != g {
+		t.Errorf("got: %q, expect: %q", g, e)
+	}
+}
+
 func ptr[T any](v T) *T {
 	return &v
 }

--- a/tag.go
+++ b/tag.go
@@ -87,31 +87,6 @@ func (tp *tagpr) tagRelease(ctx context.Context, pr *github.PullRequest, currVer
 	// Add prefix for monorepo support
 	fullNextTag := fullTag(tp.normalizedTagPrefix, nextTag)
 
-	previousTag := &latestSemverTag
-	if *previousTag == "" {
-		previousTag = nil
-	}
-
-	// To avoid putting pull requests created by tagpr itself in the release notes,
-	// we generate release notes in advance.
-	// Get the previous commitish to avoid picking up the merge of the pull
-	// request made by tagpr.
-	targetCommitish, _, err := tp.c.Git("rev-parse", "HEAD~")
-	if err != nil {
-		return nil
-	}
-	releases, resp, err := tp.gh.Repositories.GenerateReleaseNotes(
-		ctx, tp.owner, tp.repo, &github.GenerateNotesOptions{
-			TagName:               fullNextTag,
-			PreviousTagName:       previousTag,
-			TargetCommitish:       &targetCommitish,
-			ConfigurationFilePath: github.Ptr(tp.cfg.ReleaseYAMLPath()),
-		})
-	if err != nil {
-		showGHError(err, resp)
-		return err
-	}
-
 	if _, _, err := tp.c.Git("tag", fullNextTag); err != nil {
 		return err
 	}
@@ -125,27 +100,48 @@ func (tp *tagpr) tagRelease(ctx context.Context, pr *github.PullRequest, currVer
 		return nil
 	}
 
+	var releaseName, releaseBody string
 	if prog := tp.cfg.ReleaseNoteCommand(); prog != "" {
-		baseRef := ""
-		if previousTag != nil {
-			baseRef = *previousTag
-		}
-		out, err := tp.execReleaseNoteCommand(prog, baseRef, fullNextTag)
+		out, err := tp.execReleaseNoteCommand(prog, latestSemverTag, fullNextTag)
 		if err != nil {
 			return fmt.Errorf("releaseNoteCommand failed: %w", err)
 		}
-		if out != "" {
-			releases.Body = strings.TrimRight(releases.Body, "\n") + "\n\n" + out
+		releaseName, releaseBody = fullNextTag, out
+	} else {
+		previousTag := &latestSemverTag
+		if *previousTag == "" {
+			previousTag = nil
 		}
+
+		// To avoid putting pull requests created by tagpr itself in the release notes,
+		// we generate release notes in advance.
+		// Get the previous commitish to avoid picking up the merge of the pull
+		// request made by tagpr.
+		targetCommitish, _, err := tp.c.Git("rev-parse", "HEAD~")
+		if err != nil {
+			return nil
+		}
+		releases, resp, err := tp.gh.Repositories.GenerateReleaseNotes(
+			ctx, tp.owner, tp.repo, &github.GenerateNotesOptions{
+				TagName:               fullNextTag,
+				PreviousTagName:       previousTag,
+				TargetCommitish:       &targetCommitish,
+				ConfigurationFilePath: github.Ptr(tp.cfg.ReleaseYAMLPath()),
+			})
+		if err != nil {
+			showGHError(err, resp)
+			return err
+		}
+		releaseName, releaseBody = releases.Name, releases.Body
 	}
 
 	// Don't use GenerateReleaseNote flag and use pre generated one
-	_, resp, err = tp.gh.Repositories.CreateRelease(
+	_, resp, err := tp.gh.Repositories.CreateRelease(
 		ctx, tp.owner, tp.repo, &github.RepositoryRelease{
 			TagName:         &fullNextTag,
 			TargetCommitish: &releaseBranch,
-			Name:            &releases.Name,
-			Body:            &releases.Body,
+			Name:            &releaseName,
+			Body:            &releaseBody,
 			Draft:           github.Ptr(tp.cfg.ReleaseDraft()),
 		})
 	if err != nil {

--- a/tag.go
+++ b/tag.go
@@ -2,6 +2,7 @@ package tagpr
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -123,6 +124,21 @@ func (tp *tagpr) tagRelease(ctx context.Context, pr *github.PullRequest, currVer
 	if !tp.cfg.Release() {
 		return nil
 	}
+
+	if prog := tp.cfg.ReleaseNoteCommand(); prog != "" {
+		baseRef := ""
+		if previousTag != nil {
+			baseRef = *previousTag
+		}
+		out, err := tp.execReleaseNoteCommand(prog, baseRef, fullNextTag)
+		if err != nil {
+			return fmt.Errorf("releaseNoteCommand failed: %w", err)
+		}
+		if out != "" {
+			releases.Body = strings.TrimRight(releases.Body, "\n") + "\n\n" + out
+		}
+	}
+
 	// Don't use GenerateReleaseNote flag and use pre generated one
 	_, resp, err = tp.gh.Repositories.CreateRelease(
 		ctx, tp.owner, tp.repo, &github.RepositoryRelease{

--- a/tag.go
+++ b/tag.go
@@ -100,9 +100,18 @@ func (tp *tagpr) tagRelease(ctx context.Context, pr *github.PullRequest, currVer
 		return nil
 	}
 
+	// To avoid putting pull requests created by tagpr itself in the release notes,
+	// we generate release notes in advance.
+	// Get the previous commitish to avoid picking up the merge of the pull
+	// request made by tagpr.
+	targetCommitish, _, err := tp.c.Git("rev-parse", "HEAD~")
+	if err != nil {
+		return nil
+	}
+
 	var releaseName, releaseBody string
 	if prog := tp.cfg.ReleaseNoteCommand(); prog != "" {
-		out, err := tp.execReleaseNoteCommand(prog, latestSemverTag, fullNextTag)
+		out, err := tp.execReleaseNoteCommand(prog, latestSemverTag, fullNextTag, targetCommitish)
 		if err != nil {
 			return fmt.Errorf("releaseNoteCommand failed: %w", err)
 		}
@@ -113,14 +122,6 @@ func (tp *tagpr) tagRelease(ctx context.Context, pr *github.PullRequest, currVer
 			previousTag = nil
 		}
 
-		// To avoid putting pull requests created by tagpr itself in the release notes,
-		// we generate release notes in advance.
-		// Get the previous commitish to avoid picking up the merge of the pull
-		// request made by tagpr.
-		targetCommitish, _, err := tp.c.Git("rev-parse", "HEAD~")
-		if err != nil {
-			return nil
-		}
 		releases, resp, err := tp.gh.Repositories.GenerateReleaseNotes(
 			ctx, tp.owner, tp.repo, &github.GenerateNotesOptions{
 				TagName:               fullNextTag,

--- a/tagpr.go
+++ b/tagpr.go
@@ -785,18 +785,17 @@ func (tp *tagpr) Run(ctx context.Context) error {
 	}
 
 	draftNextTag := fullTag(tp.normalizedTagPrefix, nextVer.Tag())
-	changelog, orig, err := gch.Draft(ctx, draftNextTag, releaseBranch, time.Now())
-	if err != nil {
-		return err
-	}
-
+	var changelog, orig string
 	if prog := tp.cfg.ReleaseNoteCommand(); prog != "" {
 		out, err := tp.execReleaseNoteCommand(prog, latestSemverTag, draftNextTag)
 		if err != nil {
 			return fmt.Errorf("releaseNoteCommand failed: %w", err)
 		}
-		if out != "" {
-			changelog = strings.TrimRight(changelog, "\n") + "\n\n" + out + "\n"
+		changelog, orig = out, out
+	} else {
+		changelog, orig, err = gch.Draft(ctx, draftNextTag, releaseBranch, time.Now())
+		if err != nil {
+			return err
 		}
 	}
 

--- a/tagpr.go
+++ b/tagpr.go
@@ -790,6 +790,16 @@ func (tp *tagpr) Run(ctx context.Context) error {
 		return err
 	}
 
+	if prog := tp.cfg.ReleaseNoteCommand(); prog != "" {
+		out, err := tp.execReleaseNoteCommand(prog, latestSemverTag, draftNextTag)
+		if err != nil {
+			return fmt.Errorf("releaseNoteCommand failed: %w", err)
+		}
+		if out != "" {
+			changelog = strings.TrimRight(changelog, "\n") + "\n\n" + out + "\n"
+		}
+	}
+
 	if tp.cfg.changelog == nil || *tp.cfg.changelog {
 		changelogMd := tp.cfg.ChangelogFile()
 		if !exists(changelogMd) {
@@ -1002,6 +1012,23 @@ func (tp *tagpr) Exec(prog string, currVer, nextVer *semv) {
 		"TAGPR_CURRENT_VERSION": currVer.Tag(),
 		"TAGPR_NEXT_VERSION":    nextVer.Tag(),
 	})
+}
+
+// execReleaseNoteCommand runs prog with baseRef and headRef as positional
+// arguments ($1 and $2), returning its trimmed standard output.
+func (tp *tagpr) execReleaseNoteCommand(prog, baseRef, headRef string) (string, error) {
+	var progArgs []string
+	if strings.ContainsAny(prog, " \n") {
+		progArgs = []string{"-c", prog, "sh", baseRef, headRef}
+		prog = "sh"
+	} else {
+		progArgs = []string{baseRef, headRef}
+	}
+	out, _, err := tp.c.Cmd(prog, progArgs, map[string]string{
+		"TAGPR_BASE_REF": baseRef,
+		"TAGPR_HEAD_REF": headRef,
+	})
+	return out, err
 }
 
 func (tp *tagpr) defaultBranch() (string, error) {

--- a/tagpr.go
+++ b/tagpr.go
@@ -787,7 +787,7 @@ func (tp *tagpr) Run(ctx context.Context) error {
 	draftNextTag := fullTag(tp.normalizedTagPrefix, nextVer.Tag())
 	var changelog, orig string
 	if prog := tp.cfg.ReleaseNoteCommand(); prog != "" {
-		out, err := tp.execReleaseNoteCommand(prog, latestSemverTag, draftNextTag)
+		out, err := tp.execReleaseNoteCommand(prog, latestSemverTag, draftNextTag, releaseBranch)
 		if err != nil {
 			return fmt.Errorf("releaseNoteCommand failed: %w", err)
 		}
@@ -1014,8 +1014,10 @@ func (tp *tagpr) Exec(prog string, currVer, nextVer *semv) {
 }
 
 // execReleaseNoteCommand runs prog with baseRef and headRef as positional
-// arguments ($1 and $2), returning its trimmed standard output.
-func (tp *tagpr) execReleaseNoteCommand(prog, baseRef, headRef string) (string, error) {
+// arguments ($1 and $2), returning its trimmed standard output. targetCommitish
+// is the commit-ish tagpr would have passed as TargetCommitish to GitHub's
+// GenerateReleaseNotes API, exposed for parity since that API is bypassed.
+func (tp *tagpr) execReleaseNoteCommand(prog, baseRef, headRef, targetCommitish string) (string, error) {
 	var progArgs []string
 	if strings.ContainsAny(prog, " \n") {
 		progArgs = []string{"-c", prog, "sh", baseRef, headRef}
@@ -1024,8 +1026,9 @@ func (tp *tagpr) execReleaseNoteCommand(prog, baseRef, headRef string) (string, 
 		progArgs = []string{baseRef, headRef}
 	}
 	out, _, err := tp.c.Cmd(prog, progArgs, map[string]string{
-		"TAGPR_BASE_REF": baseRef,
-		"TAGPR_HEAD_REF": headRef,
+		"TAGPR_BASE_REF":         baseRef,
+		"TAGPR_HEAD_REF":         headRef,
+		"TAGPR_TARGET_COMMITISH": targetCommitish,
 	})
 	return out, err
 }

--- a/tagpr_test.go
+++ b/tagpr_test.go
@@ -647,7 +647,7 @@ func TestExecReleaseNoteCommand(t *testing.T) {
 	}
 
 	t.Run("plain command receives base/head ref as positional args", func(t *testing.T) {
-		out, err := tp.execReleaseNoteCommand("echo", "v1.0.0", "v1.1.0")
+		out, err := tp.execReleaseNoteCommand("echo", "v1.0.0", "v1.1.0", "main")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -657,7 +657,7 @@ func TestExecReleaseNoteCommand(t *testing.T) {
 	})
 
 	t.Run("shell script receives base/head ref via $1 and $2", func(t *testing.T) {
-		out, err := tp.execReleaseNoteCommand(`echo "$1 $2"`, "v1.0.0", "v1.1.0")
+		out, err := tp.execReleaseNoteCommand(`echo "$1 $2"`, "v1.0.0", "v1.1.0", "main")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -667,7 +667,7 @@ func TestExecReleaseNoteCommand(t *testing.T) {
 	})
 
 	t.Run("first release has empty base ref", func(t *testing.T) {
-		out, err := tp.execReleaseNoteCommand(`echo "[$1] $2"`, "", "v1.0.0")
+		out, err := tp.execReleaseNoteCommand(`echo "[$1] $2"`, "", "v1.0.0", "main")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -676,8 +676,18 @@ func TestExecReleaseNoteCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("target commitish is exposed via TAGPR_TARGET_COMMITISH", func(t *testing.T) {
+		out, err := tp.execReleaseNoteCommand(`echo "$TAGPR_TARGET_COMMITISH"`, "v1.0.0", "v1.1.0", "deadbeef")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := "deadbeef"; out != want {
+			t.Errorf("got: %q, want: %q", out, want)
+		}
+	})
+
 	t.Run("non-zero exit status is returned as an error", func(t *testing.T) {
-		_, err := tp.execReleaseNoteCommand("false", "v1.0.0", "v1.1.0")
+		_, err := tp.execReleaseNoteCommand("false", "v1.0.0", "v1.1.0", "main")
 		if err == nil {
 			t.Error("want error, got nil")
 		}

--- a/tagpr_test.go
+++ b/tagpr_test.go
@@ -3,6 +3,7 @@ package tagpr
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"strings"
@@ -638,4 +639,47 @@ func TestIsTagPR(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExecReleaseNoteCommand(t *testing.T) {
+	tp := &tagpr{
+		c: &commander{outStream: io.Discard, errStream: io.Discard},
+	}
+
+	t.Run("plain command receives base/head ref as positional args", func(t *testing.T) {
+		out, err := tp.execReleaseNoteCommand("echo", "v1.0.0", "v1.1.0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := "v1.0.0 v1.1.0"; out != want {
+			t.Errorf("got: %q, want: %q", out, want)
+		}
+	})
+
+	t.Run("shell script receives base/head ref via $1 and $2", func(t *testing.T) {
+		out, err := tp.execReleaseNoteCommand(`echo "$1 $2"`, "v1.0.0", "v1.1.0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := "v1.0.0 v1.1.0"; out != want {
+			t.Errorf("got: %q, want: %q", out, want)
+		}
+	})
+
+	t.Run("first release has empty base ref", func(t *testing.T) {
+		out, err := tp.execReleaseNoteCommand(`echo "[$1] $2"`, "", "v1.0.0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := "[] v1.0.0"; out != want {
+			t.Errorf("got: %q, want: %q", out, want)
+		}
+	})
+
+	t.Run("non-zero exit status is returned as an error", func(t *testing.T) {
+		_, err := tp.execReleaseNoteCommand("false", "v1.0.0", "v1.1.0")
+		if err == nil {
+			t.Error("want error, got nil")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Closes #298

Adds a `tagpr.releaseNoteCommand` config option that runs a user-defined command to generate the release note content, receiving the previous tag and the new tag as positional arguments (`$1`/`$2`; `$1` is empty for the first release).

**Note on design vs. the original issue proposal**: the issue described appending the command's output as an *additional section* on top of GitHub's auto-generated release notes. This implementation instead has the command's output **fully replace** the release note content — when `releaseNoteCommand` is configured, GitHub's `GenerateReleaseNotes` API is not called at all, for both:
- the CHANGELOG.md draft entry (drafted while building/updating the release PR)
- the GitHub Release body (created at tag time)

This gives full control over the release note content to the command and avoids an extra GitHub API dependency when it's not needed, at the cost of losing GitHub's auto-generated content (PR list, contributors, etc.) unless the command itself reproduces it.

If the option is not set, tagpr behaves exactly as before (GitHub's release notes generation API is used).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Manual smoke test with a real `releaseNoteCommand` script against a live repo (not done in this environment)