### PR TITLE
use client-id instead of using app-id on create-github-app-token

### DIFF
--- a/.github/workflows/tagpr-docs.yaml
+++ b/.github/workflows/tagpr-docs.yaml
@@ -19,7 +19,7 @@ jobs:
       id: generate_token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.CLIENT_ID }}
         private-key: ${{ secrets.PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write

--- a/.github/workflows/tagpr-gh2changelog.yaml
+++ b/.github/workflows/tagpr-gh2changelog.yaml
@@ -19,7 +19,7 @@ jobs:
       id: generate_token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.CLIENT_ID }}
         private-key: ${{ secrets.PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -17,7 +17,7 @@ jobs:
       id: generate_token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.CLIENT_ID }}
         private-key: ${{ secrets.PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write

--- a/docs/guides/publish-after-release.md
+++ b/docs/guides/publish-after-release.md
@@ -51,7 +51,7 @@ token must be used by both checkout and tagpr:
   id: app-token
   uses: actions/create-github-app-token@v3
   with:
-    app-id: ${{ secrets.APP_ID }}
+    client-id: ${{ secrets.CLIENT_ID }}
     private-key: ${{ secrets.PRIVATE_KEY }}
     permission-contents: write
     permission-pull-requests: write


### PR DESCRIPTION
suppress `Input 'app-id' has been deprecated with message: Use 'client-id' instead.` warnings.