### PR TITLE
docs: explain token workflow options

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,11 +229,11 @@ publishing or deployment step in the same workflow:
 
 ### Triggering a separate workflow
 
-Events created with the repository's `GITHUB_TOKEN` do not start another GitHub Actions
-workflow. This prevents accidental recursive workflow runs. Therefore, a tag created by
-tagpr with `GITHUB_TOKEN` will not trigger a separate tag-based release workflow.
-Workflows on release pull requests created with `GITHUB_TOKEN` also require approval
-from a user with write access.
+Events created with the repository's `GITHUB_TOKEN` do not normally start another
+GitHub Actions workflow. Therefore, a tag created by tagpr with `GITHUB_TOKEN` will not
+trigger a separate tag-based release workflow. Eligible workflows for release pull
+requests are an exception: GitHub queues them, but they require approval from a user
+with write access before they run.
 
 Either run publishing in this workflow using `steps.tagpr.outputs.tag`, or supply tagpr
 with a GitHub App installation token when a separate tag-triggered workflow must run.

--- a/README.md
+++ b/README.md
@@ -232,39 +232,13 @@ publishing or deployment step in the same workflow:
 Events created with the repository's `GITHUB_TOKEN` do not start another GitHub Actions
 workflow. This prevents accidental recursive workflow runs. Therefore, a tag created by
 tagpr with `GITHUB_TOKEN` will not trigger a separate tag-based release workflow.
+Workflows on release pull requests created with `GITHUB_TOKEN` also require approval
+from a user with write access.
 
-If the tag must trigger another workflow, use a token from a GitHub App or another token
-that has the required repository permissions. A GitHub App installation token is
-recommended because it is short-lived. For simplicity, the following example uses a
-personal access token stored as `GH_PAT`:
-
-```yaml
-name: tagpr
-on:
-  push:
-    branches: ["main"]
-
-permissions:
-  contents: write
-  pull-requests: write
-  issues: read
-
-jobs:
-  tagpr:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        token: ${{ secrets.GH_PAT }}
-        persist-credentials: false
-    - uses: Songmu/tagpr@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-```
-
-See GitHub's documentation on
-[triggering a workflow from a workflow][github-token-trigger] for the underlying token
-behavior.
+Either run publishing in this workflow using `steps.tagpr.outputs.tag`, or supply tagpr
+with a GitHub App installation token when a separate tag-triggered workflow must run.
+See [Publishing after a release](docs/guides/publish-after-release.md) for the tradeoffs,
+examples, required permissions, and token setup.
 
 ## Common configurations
 
@@ -592,7 +566,6 @@ configuration, relevant tags, and the tagpr log.
 
 [actions]: https://github.com/Songmu/tagpr/actions?workflow=test
 [github-generate-release-notes-api]: https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release
-[github-token-trigger]: https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow
 [issues]: https://github.com/Songmu/tagpr/issues
 [license]: https://github.com/Songmu/tagpr/blob/main/LICENSE
 [marketplace]: https://github.com/marketplace/actions/automate-pull-request-generation-and-tagging-for-releases-using-tagpr

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,17 +46,20 @@ release pull request, inspect merged pull requests, and create tags and GitHub R
 `persist-credentials: false` ensures that tagpr uses the token supplied through its
 environment for Git operations instead of credentials retained by checkout.
 
-The default `GITHUB_TOKEN` setup does not automatically trigger another workflow from a
-tag or release PR branch created by tagpr. See
-[Publishing after a release](guides/publish-after-release.md) for the constraints and
-the available workflow layouts.
+With the default `GITHUB_TOKEN`, a tag created by tagpr does not trigger another
+workflow. Eligible `pull_request` workflows for the release PR are queued, but require
+approval from a user with write access before they run. See
+[Publishing after a release](guides/publish-after-release.md) for details and alternative
+workflow layouts.
 
 ## Enable pull request creation
 
 In the repository, open **Settings > Actions > General > Workflow permissions** and
 enable **Allow GitHub Actions to create and approve pull requests**.
 
-This repository setting is required in addition to the workflow's `permissions` block.
+This repository setting is required in addition to the workflow's `permissions` block
+when tagpr uses `GITHUB_TOKEN`. A GitHub App token is governed by the App's permissions
+instead.
 
 ## Run tagpr for the first time
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,11 @@ release pull request, inspect merged pull requests, and create tags and GitHub R
 `persist-credentials: false` ensures that tagpr uses the token supplied through its
 environment for Git operations instead of credentials retained by checkout.
 
+The default `GITHUB_TOKEN` setup does not automatically trigger another workflow from a
+tag or release PR branch created by tagpr. See
+[Publishing after a release](guides/publish-after-release.md) for the constraints and
+the available workflow layouts.
+
 ## Enable pull request creation
 
 In the repository, open **Settings > Actions > General > Workflow permissions** and

--- a/docs/guides/publish-after-release.md
+++ b/docs/guides/publish-after-release.md
@@ -7,23 +7,20 @@ between publishing in the tagpr workflow and triggering a separate workflow.
 
 The repository's `GITHUB_TOKEN` is the simplest credential to use with tagpr because
 GitHub creates it automatically for each workflow run. However, events created with
-`GITHUB_TOKEN` do not normally start another workflow run. This affects tagpr in two
-places:
+`GITHUB_TOKEN` [do not normally start another workflow run][github-token-trigger]. This
+affects tagpr in two places:
 
 - a tag created by tagpr does not trigger a workflow configured with `on.push.tags`;
-- workflows on the release PR created by tagpr do not run automatically.
-
-GitHub allows workflows on pull requests created by `github-actions[bot]` to run after
-[a user with write access approves them][bot-pr-approval]. This makes the release PR
-workflows available with `GITHUB_TOKEN`, but adds a manual approval step.
+- eligible `pull_request` workflows for the release PR are queued, but do not run until
+  [a user with write access approves them][bot-pr-approval].
 
 There are two ways to run publishing or deployment automatically after tagpr creates a
 tag:
 
 | Layout | Advantage | Tradeoff |
 | --- | --- | --- |
-| Publish in the tagpr workflow | Uses `GITHUB_TOKEN` without additional credentials | Keeps tagpr and publishing in the same workflow |
-| Trigger a separate tag workflow | Keeps release responsibilities in separate workflows | Requires a token that can trigger workflows |
+| Publish in the tagpr workflow | Uses `GITHUB_TOKEN` without additional credentials | Release PR workflows require approval, and publishing shares tagpr's workflow permissions and environment |
+| Trigger a separate tag workflow | Separates release responsibilities and lets tag and release PR workflows run automatically | Requires a token that can trigger workflows |
 
 ## Publish in the same workflow
 
@@ -59,9 +56,7 @@ Other available outputs are:
 
 ## Trigger a separate workflow
 
-GitHub does not start another workflow for events created with the repository's
-`GITHUB_TOKEN`. As a result, a tag created by tagpr with `GITHUB_TOKEN` does not trigger
-a workflow configured with:
+To keep publishing or deployment in a workflow configured with `on.push.tags`:
 
 ```yaml
 on:
@@ -70,9 +65,9 @@ on:
     - "v*"
 ```
 
-Supply tagpr with a token other than `GITHUB_TOKEN` when the tag must trigger a separate
-workflow. A personal access token works, but a short-lived GitHub App installation
-token created by [`actions/create-github-app-token`][create-app-token] is recommended.
+Supply tagpr with a token other than `GITHUB_TOKEN` so the tag can trigger that
+workflow. A personal access token works, but a short-lived GitHub App installation token
+created by [`actions/create-github-app-token`][create-app-token] is recommended.
 
 The GitHub App must be installed on the repository with these permissions:
 
@@ -108,6 +103,10 @@ and use it for both checkout and tagpr:
 Tags and release PR updates created with this installation token can trigger their
 respective workflows without the `GITHUB_TOKEN` restrictions.
 
+The repository setting **Allow GitHub Actions to create and approve pull requests**
+controls `GITHUB_TOKEN`; GitHub App tokens are instead governed by the App's
+permissions.
+
 ## Keep publishing recoverable
 
 Regardless of which workflow layout you choose, make the publishing operation accept an
@@ -138,3 +137,4 @@ For the action's complete output reference, see the
 [bot-pr-approval]: https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/
 [create-app-token]: https://github.com/actions/create-github-app-token
 [ecschedule-tagpr]: https://github.com/Songmu/ecschedule/blob/main/.github/workflows/tagpr.yaml
+[github-token-trigger]: https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow

--- a/docs/guides/publish-after-release.md
+++ b/docs/guides/publish-after-release.md
@@ -3,10 +3,32 @@
 tagpr creates the version tag and exposes outputs that downstream steps can use. Choose
 between publishing in the tagpr workflow and triggering a separate workflow.
 
+## `GITHUB_TOKEN` constraints
+
+The repository's `GITHUB_TOKEN` is the simplest credential to use with tagpr because
+GitHub creates it automatically for each workflow run. However, events created with
+`GITHUB_TOKEN` do not normally start another workflow run. This affects tagpr in two
+places:
+
+- a tag created by tagpr does not trigger a workflow configured with `on.push.tags`;
+- workflows on the release PR created by tagpr do not run automatically.
+
+GitHub allows workflows on pull requests created by `github-actions[bot]` to run after
+[a user with write access approves them][bot-pr-approval]. This makes the release PR
+workflows available with `GITHUB_TOKEN`, but adds a manual approval step.
+
+There are two ways to run publishing or deployment automatically after tagpr creates a
+tag:
+
+| Layout | Advantage | Tradeoff |
+| --- | --- | --- |
+| Publish in the tagpr workflow | Uses `GITHUB_TOKEN` without additional credentials | Keeps tagpr and publishing in the same workflow |
+| Trigger a separate tag workflow | Keeps release responsibilities in separate workflows | Requires a token that can trigger workflows |
+
 ## Publish in the same workflow
 
 The `tag` output is non-empty only when tagpr creates a tag. Use it as the condition for
-a publishing or deployment step:
+a publishing or deployment step in the same workflow:
 
 ```yaml
 - uses: actions/checkout@v6
@@ -18,11 +40,16 @@ a publishing or deployment step:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 - name: Publish
   if: steps.tagpr.outputs.tag != ''
-  run: ./scripts/publish "${{ steps.tagpr.outputs.tag }}"
+  uses: ./.github/actions/release
+  with:
+    tag: ${{ steps.tagpr.outputs.tag }}
+    token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-This is the simplest option when publishing can run in the same permissions and
-environment as tagpr.
+This layout does not need a GitHub App or personal access token. Keeping the publishing
+logic in a script or local composite action limits the coupling even though tagpr and
+publishing share a workflow. See
+[Songmu/ecschedule's tagpr workflow][ecschedule-tagpr] for a complete example.
 
 Other available outputs are:
 
@@ -43,8 +70,19 @@ on:
     - "v*"
 ```
 
-Use a GitHub App installation token when the tag must trigger a separate workflow. The
-token must be used by both checkout and tagpr:
+Supply tagpr with a token other than `GITHUB_TOKEN` when the tag must trigger a separate
+workflow. A personal access token works, but a short-lived GitHub App installation
+token created by [`actions/create-github-app-token`][create-app-token] is recommended.
+
+The GitHub App must be installed on the repository with these permissions:
+
+- Contents: Read and write
+- Pull requests: Read and write
+- Issues: Read-only
+
+Creating the App, installing it, and storing its credentials are covered by the
+`actions/create-github-app-token` documentation. Once configured, generate the token
+and use it for both checkout and tagpr:
 
 ```yaml
 - name: Generate token
@@ -67,8 +105,8 @@ token must be used by both checkout and tagpr:
     GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 ```
 
-The GitHub App must be installed on the repository and granted the requested
-permissions.
+Tags and release PR updates created with this installation token can trigger their
+respective workflows without the `GITHUB_TOKEN` restrictions.
 
 ## Keep publishing recoverable
 
@@ -96,3 +134,7 @@ Both the tagpr workflow and a recovery workflow can then call the same operation
 
 For the action's complete output reference, see the
 [README](../../README.md#outputs).
+
+[bot-pr-approval]: https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/
+[create-app-token]: https://github.com/actions/create-github-app-token
+[ecschedule-tagpr]: https://github.com/Songmu/ecschedule/blob/main/.github/workflows/tagpr.yaml


### PR DESCRIPTION
## Summary

- document the workflow-trigger restrictions of the default `GITHUB_TOKEN`
- compare same-workflow publishing with a separate tag-triggered workflow
- recommend short-lived GitHub App tokens and show the required permissions
- link to the ecschedule workflow as a complete `steps.tagpr.outputs.tag` example

## Checks

- `goimports -w .`
- `go vet ./...`
- `staticcheck ./...`
- `go test ./...`
- `git diff --check`