### PR TITLE
docs: explain immutable release workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ adopt.
 - [Changelog and GitHub Releases](docs/guides/changelog-and-releases.md)
 - [Release preparation commands](docs/guides/release-commands.md)
 - [Publishing after a release](docs/guides/publish-after-release.md)
+- [Immutable GitHub Releases](docs/guides/immutable-releases.md)
 - [Configuration index](docs/reference/configuration.md)
 - [Release pull request templates](docs/reference/templates.md)
 

--- a/docs/concepts/release-flow.md
+++ b/docs/concepts/release-flow.md
@@ -154,3 +154,7 @@ tagpr marks the release commit and can create the GitHub Release, but package bu
 registry uploads, and deployment remain project-specific. Keeping those steps outside
 tagpr lets each project use its own release tooling while relying on a consistent
 release decision and tag.
+
+Repositories that make GitHub Releases immutable must attach assets before publishing.
+See [Immutable GitHub Releases](../guides/immutable-releases.md) for the supported
+division of responsibility between tagpr and downstream release tooling.

--- a/docs/guides/changelog-and-releases.md
+++ b/docs/guides/changelog-and-releases.md
@@ -85,6 +85,11 @@ artifacts tagpr writes:
 The release pull request body still uses GitHub's generated notes when changelog-file or
 GitHub Release creation is disabled.
 
+If release assets must be built after tagging, see
+[Immutable GitHub Releases](immutable-releases.md) before enabling immutable releases.
+It explains when to let tagpr prepare a draft and when to delegate release creation to
+another workflow.
+
 [github-generated-release-notes]: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
 [github-generate-release-notes-api]: https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release
 [keep-a-changelog]: https://keepachangelog.com/

--- a/docs/guides/immutable-releases.md
+++ b/docs/guides/immutable-releases.md
@@ -1,0 +1,134 @@
+# Immutable GitHub Releases
+
+tagpr creates a tag and a published GitHub Release by default. Repositories that enable
+[immutable releases][github-immutable-releases] must finish building and attaching
+assets before publishing the release: after publication, the associated tag cannot be
+moved and release assets cannot be modified or deleted.
+
+GitHub recommends creating a draft release, attaching every asset, and publishing the
+draft only when it is complete. Choose which tool owns that sequence before enabling
+immutable releases.
+
+## Choose the release owner
+
+tagpr supports two patterns for coordinating with a later build or publishing workflow:
+
+| Configuration | Use when | Release owner |
+| --- | --- | --- |
+| `tagpr.release = draft` | You want tagpr to generate the release title and notes | tagpr creates the draft; the later workflow adds assets and publishes it |
+| `tagpr.release = false` | You want a strict boundary at tag creation | The later workflow creates, populates, and publishes the release |
+
+Do not leave `tagpr.release = true` when a later workflow needs to upload assets to an
+immutable release. That setting publishes the release immediately, so it is already
+immutable when the later workflow runs.
+
+In either pattern, make the downstream operation accept an explicit tag and remain safe
+to rerun. It should update the draft for that exact tag rather than create another tag
+or a second release.
+
+## Let tagpr prepare a draft release
+
+Set `release = draft` to keep tagpr's generated title and release notes:
+
+```ini
+[tagpr]
+    release = draft
+```
+
+After tagpr creates a tag, a later step can build the assets, upload them to the existing
+draft, and publish it:
+
+```yaml
+- id: tagpr
+  uses: Songmu/tagpr@v1
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+- name: Build release assets
+  if: steps.tagpr.outputs.tag != ''
+  run: ./scripts/build-release "${{ steps.tagpr.outputs.tag }}"
+
+- name: Upload assets and publish the draft
+  if: steps.tagpr.outputs.tag != ''
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    TAG: ${{ steps.tagpr.outputs.tag }}
+  run: |
+    gh release upload "$TAG" dist/project.tar.gz dist/checksums.txt --clobber
+    gh release edit "$TAG" --draft=false
+```
+
+The upload must succeed before the command publishes the draft. Keep publishing in the
+same workflow when using `GITHUB_TOKEN`; tags created with that token do not normally
+trigger another workflow. To use a separate tag-triggered workflow, provide tagpr with
+a token that can trigger workflows. See
+[Publishing after a release](publish-after-release.md#github_token-constraints) for the
+authentication and workflow-layout tradeoffs.
+
+Use `--clobber` only for assets that the build can reproduce from the same tag. It lets
+a retry replace assets uploaded by a partially completed earlier attempt. Monitor for
+drafts that remain unpublished after a failed or cancelled workflow, and rerun the
+operation for their explicit tags.
+
+### Reuse the draft with GoReleaser
+
+GoReleaser v2.5 or later can populate the draft created by tagpr. Pair the tagpr setting
+above with:
+
+```yaml
+# .goreleaser.yml
+release:
+  use_existing_draft: true
+```
+
+Without `release = draft`, tagpr publishes too early for an immutable release.
+Without `use_existing_draft: true`, GoReleaser may try to create a separate release
+instead of adding assets to tagpr's draft. The complete coordination pattern is
+described in
+[Coordinating tagpr and GoReleaser with immutable releases][tagpr-goreleaser-article].
+
+## Let another workflow create the release
+
+Set `release = false` when tagpr should own only the release pull request and tag:
+
+```ini
+[tagpr]
+    release = false
+```
+
+The downstream workflow then owns release notes, assets, publication, and recovery. For
+example, accept a tag input for manual recovery and fall back to the pushed tag during a
+normal tag-triggered run:
+
+```yaml
+- name: Create a draft and attach assets
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    TAG: ${{ inputs.tag || github.ref_name }}
+  run: |
+    if ! gh release view "$TAG" >/dev/null 2>&1; then
+      gh release create "$TAG" --draft --generate-notes --verify-tag
+    fi
+    gh release upload "$TAG" \
+      dist/project.tar.gz dist/checksums.txt \
+      --clobber
+
+- name: Publish the completed release
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    TAG: ${{ inputs.tag || github.ref_name }}
+  run: gh release edit "$TAG" --draft=false
+```
+
+This separation is useful when an existing release tool or workflow already controls
+release-note generation. Ensure that the workflow is triggered reliably: a tag created
+by tagpr with `GITHUB_TOKEN` does not normally start a tag-triggered workflow. The
+[separate workflow guidance](publish-after-release.md#trigger-a-separate-workflow)
+explains how to use a GitHub App installation token instead.
+
+The example detects and reuses an existing draft instead of blindly running
+`gh release create` again. Keep asset generation deterministic and publish only after
+every required upload has completed.
+
+[github-immutable-releases]: https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases
+[tagpr-goreleaser-article]: https://songmu.jp/riji/entry/2025-09-05-coordinate-tagpr-and-goreleaser-with-immutable-releases.html

--- a/docs/guides/immutable-releases.md
+++ b/docs/guides/immutable-releases.md
@@ -61,7 +61,13 @@ draft, and publish it:
 The upload must succeed before the command publishes the draft. Keep publishing in the
 same workflow when using `GITHUB_TOKEN`; tags created with that token do not normally
 trigger another workflow. To use a separate tag-triggered workflow, provide tagpr with
-a token that can trigger workflows. See
+a token that can trigger workflows.
+
+The separate workflow can start before the draft exists because tagpr pushes the tag
+before it creates the GitHub Release. Retry the draft lookup until it becomes available,
+or dispatch the publishing workflow only after the tagpr job completes. Changing the
+token makes the workflow trigger possible, but does not by itself prevent this race.
+See
 [Publishing after a release](publish-after-release.md#github_token-constraints) for the
 authentication and workflow-layout tradeoffs.
 

--- a/docs/guides/publish-after-release.md
+++ b/docs/guides/publish-after-release.md
@@ -3,6 +3,11 @@
 tagpr creates the version tag and exposes outputs that downstream steps can use. Choose
 between publishing in the tagpr workflow and triggering a separate workflow.
 
+When the downstream operation adds GitHub Release assets and the repository uses
+immutable releases, publication must happen only after every asset is attached. See
+[Immutable GitHub Releases](immutable-releases.md) for the `tagpr.release = draft` and
+`tagpr.release = false` coordination patterns.
+
 ## `GITHUB_TOKEN` constraints
 
 The repository's `GITHUB_TOKEN` is the simplest credential to use with tagpr because

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,8 @@ and repeatable while keeping the release decision visible and reviewable.
   project-specific file changes before release.
 - [Publishing after a release](guides/publish-after-release.md) explains how to publish
   artifacts or deploy after tagpr creates a tag.
+- [Immutable GitHub Releases](guides/immutable-releases.md) explains how to attach
+  assets before publication by coordinating tagpr with a later release workflow.
 - [Configuration index](reference/configuration.md) groups the available settings by
   purpose and links to the complete reference.
 - [Release pull request templates](reference/templates.md) documents title and body
@@ -40,6 +42,8 @@ and repeatable while keeping the release decision visible and reviewable.
 | Run project-specific release changes | [Release preparation commands](guides/release-commands.md) |
 | Publish from the same workflow | [Publishing after a release](guides/publish-after-release.md#publish-in-the-same-workflow) |
 | Trigger a separate workflow | [Publishing after a release](guides/publish-after-release.md#trigger-a-separate-workflow) |
+| Publish assets with immutable releases | [Immutable GitHub Releases](guides/immutable-releases.md) |
+| Reuse a tagpr draft with GoReleaser | [Immutable GitHub Releases](guides/immutable-releases.md#reuse-the-draft-with-goreleaser) |
 | Diagnose a setup problem | [README troubleshooting](../README.md#troubleshooting) |
 
 ## Reference

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -77,6 +77,9 @@ variables, and examples.
 | --- | --- |
 | `tagpr.release` | Create a published release, a draft, or no GitHub Release |
 
+See [Immutable GitHub Releases](../guides/immutable-releases.md) when a later workflow
+must attach assets before publishing.
+
 ## Monorepos
 
 Use `tagpr.tagPrefix` to give each independently released project its own tag namespace.


### PR DESCRIPTION
## Summary

- add guidance for choosing `tagpr.release = draft` or `false` with immutable GitHub Releases
- document generic GitHub Actions and GoReleaser coordination patterns
- link the new guide from the README and existing release documentation

## Checks

- `goimports -w .`
- `go vet ./...`
- `staticcheck ./...`
- `go test ./...`
- `go build ./...`