### PR TITLE
docs: deploy site with Hugo

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,79 @@
+name: pages
+on:
+  pull_request:
+    paths:
+    - "docs/**"
+    - "README.md"
+    - ".github/workflows/pages.yaml"
+  push:
+    branches:
+    - "main"
+    paths:
+    - "docs/**"
+    - "README.md"
+    - ".github/workflows/pages.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: pages-${{ github.event_name == 'pull_request' && github.ref || 'deploy' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  HUGO_VERSION: 0.165.0
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - name: setup go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version-file: docs/site/go.mod
+        cache: false
+    - name: install hugo
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        archive="hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+        gh release download "v${HUGO_VERSION}" \
+          --repo gohugoio/hugo \
+          --pattern "$archive" \
+          --pattern "hugo_${HUGO_VERSION}_checksums.txt" \
+          --dir "$RUNNER_TEMP"
+        grep "  $archive$" "$RUNNER_TEMP/hugo_${HUGO_VERSION}_checksums.txt" \
+          | (cd "$RUNNER_TEMP" && sha256sum --check)
+        mkdir -p "$RUNNER_TEMP/hugo"
+        tar -xzf "$RUNNER_TEMP/$archive" -C "$RUNNER_TEMP/hugo" hugo
+        echo "$RUNNER_TEMP/hugo" >> "$GITHUB_PATH"
+    - name: build
+      run: ./docs/site/build.sh "$RUNNER_TEMP/site"
+    - name: upload pages artifact
+      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      with:
+        path: ${{ runner.temp }}/site
+
+  deploy:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: deploy pages
+      id: deployment
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/tagpr-docs.yaml
+++ b/.github/workflows/tagpr-docs.yaml
@@ -5,6 +5,7 @@ on:
     - "main"
     paths:
     - "docs/**"
+    - "!docs/site/**"
   workflow_dispatch:
 permissions:
   contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tagpr
 dist/
+/site/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ adopt.
 
 ## Documentation
 
+- [Published documentation](https://junkyard.song.mu/tagpr/)
 - [Documentation index](docs/index.md)
 - [Getting started](docs/getting-started.md)
 - [Adopting tagpr in an existing project](docs/guides/adopting-tagpr.md)
@@ -78,6 +79,16 @@ adopt.
 - [Immutable GitHub Releases](docs/guides/immutable-releases.md)
 - [Configuration index](docs/reference/configuration.md)
 - [Release pull request templates](docs/reference/templates.md)
+
+Build the documentation site locally with Hugo Extended 0.165.0:
+
+```console
+./docs/site/build.sh
+```
+
+The generated site is written to `site/`.
+Before the first deployment, set the repository's **Settings > Pages > Source** to
+**GitHub Actions**.
 
 ## Quickstart
 

--- a/docs/site/build.sh
+++ b/docs/site/build.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+site_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+docs_dir="$(cd "$site_dir/.." && pwd)"
+repo_dir="$(cd "$docs_dir/.." && pwd)"
+output_dir="${1:-"$repo_dir/site"}"
+
+if [[ "$output_dir" != /* ]]; then
+  output_dir="$PWD/$output_dir"
+fi
+
+mkdir -p "$output_dir"
+output_dir="$(cd "$output_dir" && pwd -P)"
+case "$output_dir" in
+  /|"$repo_dir"|"$docs_dir"|"$site_dir")
+    echo "refusing to use unsafe output directory: $output_dir" >&2
+    exit 1
+    ;;
+esac
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+mkdir -p "$work_dir/content" "$work_dir/static"
+cp "$site_dir/hugo.yaml" "$site_dir/go.mod" "$site_dir/go.sum" "$work_dir/"
+cp -R "$site_dir/layouts" "$work_dir/layouts"
+cp -R "$docs_dir/images" "$work_dir/static/images"
+
+while IFS= read -r -d '' source; do
+  relative="${source#"$docs_dir/"}"
+  target="$work_dir/content/$relative"
+  if [[ "$relative" == "index.md" ]]; then
+    target="$work_dir/content/_index.md"
+  fi
+
+  IFS= read -r heading < "$source" || heading=""
+  if [[ "$heading" != "# "* ]]; then
+    echo "documentation page must start with a level-one heading: $relative" >&2
+    exit 1
+  fi
+
+  title="${heading#\# }"
+  title="${title//\\/\\\\}"
+  title="${title//\"/\\\"}"
+
+  weight=""
+  case "$relative" in
+    getting-started.md) weight=10 ;;
+    guides/adopting-tagpr.md) weight=10 ;;
+    guides/versioning.md) weight=20 ;;
+    guides/changelog-and-releases.md) weight=30 ;;
+    guides/release-commands.md) weight=40 ;;
+    guides/publish-after-release.md) weight=50 ;;
+    guides/immutable-releases.md) weight=60 ;;
+    concepts/release-flow.md) weight=10 ;;
+    reference/configuration.md) weight=10 ;;
+    reference/templates.md) weight=20 ;;
+  esac
+
+  mkdir -p "$(dirname "$target")"
+  {
+    printf '%s\n' '---'
+    printf 'title: "%s"\n' "$title"
+    if [[ -n "$weight" ]]; then
+      printf 'weight: %s\n' "$weight"
+    fi
+    if [[ "$relative" == "index.md" ]]; then
+      printf '%s\n' 'type: docs' 'cascade:' '  type: docs'
+    fi
+    printf '%s\n\n' '---'
+    tail -n +2 "$source"
+  } > "$target"
+done < <(
+  find "$docs_dir" \
+    -path "$site_dir" -prune -o \
+    -type f -name '*.md' -print0
+)
+
+write_section() {
+  local path="$1"
+  local title="$2"
+  local weight="$3"
+  cat > "$work_dir/content/$path/_index.md" <<EOF
+---
+title: "$title"
+weight: $weight
+---
+EOF
+}
+
+write_section guides Guides 20
+write_section concepts Concepts 30
+write_section reference Reference 40
+
+hugo \
+  --source "$work_dir" \
+  --destination "$output_dir" \
+  --cleanDestinationDir \
+  --gc \
+  --minify \
+  --panicOnWarning \
+  --printPathWarnings

--- a/docs/site/go.mod
+++ b/docs/site/go.mod
@@ -1,0 +1,6 @@
+module github.com/Songmu/tagpr/docs/site
+
+go 1.25.0
+
+require github.com/imfing/hextra v0.12.3
+

--- a/docs/site/go.sum
+++ b/docs/site/go.sum
@@ -1,0 +1,2 @@
+github.com/imfing/hextra v0.12.3 h1:DZHY2rUWYteyzjlHi9r4n7Bb5e2Q+6LXe4C1Dqn0ZjM=
+github.com/imfing/hextra v0.12.3/go.mod h1:vi+yhpq8YPp/aghvJlNKVnJKcPJ/VyAEcfC1BSV9ARo=

--- a/docs/site/hugo.yaml
+++ b/docs/site/hugo.yaml
@@ -1,0 +1,42 @@
+baseURL: https://junkyard.song.mu/tagpr/
+title: tagpr
+locale: en-US
+enableRobotsTXT: true
+disableKinds:
+- taxonomy
+- term
+
+module:
+  hugoVersion:
+    extended: true
+    min: 0.165.0
+  imports:
+  - path: github.com/imfing/hextra
+
+markup:
+  goldmark:
+    renderer:
+      unsafe: false
+  highlight:
+    noClasses: false
+
+menu:
+  main:
+  - name: Search
+    weight: 1
+    params:
+      type: search
+  - name: GitHub
+    weight: 2
+    url: https://github.com/Songmu/tagpr
+    params:
+      icon: github
+
+params:
+  description: A GitHub Action for automated release pull requests and tagging
+  navbar:
+    displayTitle: true
+    displayLogo: false
+  theme:
+    default: system
+    displayToggle: true

--- a/docs/site/layouts/_markup/render-image.html
+++ b/docs/site/layouts/_markup/render-image.html
@@ -1,0 +1,15 @@
+{{- $destination := .Destination -}}
+{{- $parsed := urls.Parse $destination -}}
+{{- $src := $destination -}}
+{{- if not $parsed.IsAbs -}}
+  {{- $pageDir := "" -}}
+  {{- with .Page.File -}}
+    {{- $pageDir = .Dir -}}
+  {{- end -}}
+  {{- $asset := path.Clean (path.Join $pageDir $parsed.Path) -}}
+  {{- if not (fileExists (path.Join "static" $asset)) -}}
+    {{- errorf "unresolved documentation image %q in %s" $destination .Page.Path -}}
+  {{- end -}}
+  {{- $src = relURL $asset -}}
+{{- end -}}
+<img src="{{ $src | safeURL }}" alt="{{ .Text }}"{{ with .Title }} title="{{ . }}"{{ end }}>

--- a/docs/site/layouts/_markup/render-link.html
+++ b/docs/site/layouts/_markup/render-link.html
@@ -1,0 +1,21 @@
+{{- $destination := .Destination -}}
+{{- $parsed := urls.Parse $destination -}}
+{{- $href := $destination -}}
+{{- if and (not $parsed.IsAbs) (not (strings.HasPrefix $destination "#")) -}}
+  {{- if strings.HasSuffix $parsed.Path "README.md" -}}
+    {{- $href = "https://github.com/Songmu/tagpr/blob/main/README.md" -}}
+    {{- with $parsed.Fragment -}}
+      {{- $href = printf "%s#%s" $href . -}}
+    {{- end -}}
+  {{- else if strings.HasSuffix $parsed.Path ".md" -}}
+    {{- with .Page.GetPage $parsed.Path -}}
+      {{- $href = .RelPermalink -}}
+      {{- with $parsed.Fragment -}}
+        {{- $href = printf "%s#%s" $href . -}}
+      {{- end -}}
+    {{- else -}}
+      {{- errorf "unresolved documentation link %q in %s" $destination .Page.Path -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+<a href="{{ $href | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
## Summary

- build the existing `docs/` tree with pinned Hugo Extended 0.165.0 and Hextra 0.12.3
- preserve the current Markdown structure through temporary build staging and compatibility render hooks
- validate documentation builds on pull requests and deploy `main` through GitHub Pages Actions

## Pages

- URL: https://junkyard.song.mu/tagpr/
- Pages source is configured for GitHub Actions with HTTPS enforced

## Checks

- `./docs/site/build.sh`
- generated-site link, fragment, image, sidebar, and search validation
- `shellcheck docs/site/build.sh`
- `actionlint`
- `hugo mod verify`
- `goimports -w .`
- `go vet ./...`
- `staticcheck ./...`
- `go test ./...`
- `go build ./...`