### PR TITLE
docs: deploy Pages from docs tags

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -6,16 +6,12 @@ on:
     - "README.md"
     - ".github/workflows/pages.yaml"
   push:
-    branches:
-    - "main"
-    paths:
-    - "docs/**"
-    - "README.md"
-    - ".github/workflows/pages.yaml"
+    tags:
+    - "docs/*"
   workflow_dispatch:
 
 concurrency:
-  group: pages-${{ github.event_name == 'pull_request' && github.ref || 'deploy' }}
+  group: pages-${{ github.ref_type == 'tag' && 'deploy' || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
@@ -57,13 +53,13 @@ jobs:
     - name: build
       run: ./docs/site/build.sh "$RUNNER_TEMP/site"
     - name: upload pages artifact
-      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/docs/')
       uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
         path: ${{ runner.temp }}/site
 
   deploy:
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/docs/')
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/tagpr-docs.yaml
+++ b/.github/workflows/tagpr-docs.yaml
@@ -5,7 +5,6 @@ on:
     - "main"
     paths:
     - "docs/**"
-    - "!docs/site/**"
   workflow_dispatch:
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -80,16 +80,6 @@ adopt.
 - [Configuration index](docs/reference/configuration.md)
 - [Release pull request templates](docs/reference/templates.md)
 
-Build the documentation site locally with Hugo Extended 0.165.0:
-
-```console
-./docs/site/build.sh
-```
-
-The generated site is written to `site/`.
-Before the first deployment, set the repository's **Settings > Pages > Source** to
-**GitHub Actions**.
-
 ## Quickstart
 
 tagpr is designed to run in GitHub Actions. Add the following workflow to a repository


### PR DESCRIPTION
## Summary

- deploy GitHub Pages only from `docs/*` tags created by tagpr
- keep pull request and manual build validation without publishing
- let `docs/site/**` changes participate in the docs release flow

This follows the docs release flow in #379.

## Checks

- `actionlint .github/workflows/pages.yaml .github/workflows/tagpr-docs.yaml`
- `shellcheck docs/site/build.sh`
- `./docs/site/build.sh`
- `goimports -w .`
- `go vet ./...`
- `staticcheck ./...`
- `go test ./...`
- `go build ./...`
