### PR TITLE
docs: show release flow on site home

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@ tagpr prepares a release pull request for unreleased changes, then tags the merg
 commit and optionally creates a GitHub Release. It makes release preparation automated
 and repeatable while keeping the release decision visible and reviewable.
 
+![The release PR branch diverges from the release branch and merges back at the tagged release commit](images/release-flow.png)
+
 ## Start here
 
 - [Getting started](getting-started.md) explains the complete path from adding the

--- a/docs/site/layouts/_markup/render-image.html
+++ b/docs/site/layouts/_markup/render-image.html
@@ -6,7 +6,7 @@
   {{- with .Page.File -}}
     {{- $pageDir = .Dir -}}
   {{- end -}}
-  {{- $asset := path.Clean (path.Join $pageDir $parsed.Path) -}}
+  {{- $asset := strings.TrimPrefix "/" (path.Clean (path.Join $pageDir $parsed.Path)) -}}
   {{- if not (fileExists (path.Join "static" $asset)) -}}
     {{- errorf "unresolved documentation image %q in %s" $destination .Page.Path -}}
   {{- end -}}


### PR DESCRIPTION
## Summary

- show the release flow concept diagram on the documentation landing page
- normalize root-page image paths so Pages keeps the /tagpr/ prefix

## Checks

- `./docs/site/build.sh`
- `actionlint`
- `shellcheck docs/site/build.sh`
- `goimports -w .`
- `go vet ./...`
- `staticcheck ./...`
- `go test ./...`
- `go build ./...`