### PR TITLE
fix: ensure base URL for GitHub Enterprise Cloud has a trailing slash

### DIFF
--- a/github.go
+++ b/github.go
@@ -29,7 +29,7 @@ func ghClient(ctx context.Context, token, host string) (*github.Client, error) {
 		if strings.HasSuffix(fqdn, ".ghe.com") {
 			// for GitHub Enterprise Cloud
 			// ref. https://docs.github.com/en/enterprise-cloud@latest/rest/using-the-rest-api/getting-started-with-the-rest-api
-			host = fmt.Sprintf("https://api.%s", host)
+			host = fmt.Sprintf("https://api.%s/", host)
 		} else {
 			// ref. https://github.com/google/go-github/issues/958
 			host = fmt.Sprintf("https://%s/api/v3/", host)


### PR DESCRIPTION
## Problem

tagpr does not work against GitHub Enterprise Cloud (`*.ghe.com`) hosts.

Every API request fails with:

```
baseURL must have a trailing slash, but "https://api.<tenant>.ghe.com" does not
```

go-github validates in `NewRequest` that `client.BaseURL` ends with a trailing slash,
but the base URL built for `*.ghe.com` hosts lacked one (`url.Parse("https://api.<tenant>.ghe.com")` yields an empty path), so the check failed for all requests.

## Link
- https://github.com/google/go-github/blob/v83.0.0/github/github.go#L554